### PR TITLE
Add HF Dataset components

### DIFF
--- a/examples/components/single_node/README.md
+++ b/examples/components/single_node/README.md
@@ -5,10 +5,23 @@ with the `poetry install` command from the root of the repository.
 
 # Usage
 
+## Pandas
+
 Run with the following commad:
 
 ```
-python3 data_loading.py --extra-args '{"project_id": "storied-landing-366912"}' \
+python3 data_loading_pandas.py --extra-args '{"project_id": "storied-landing-366912"}' \
+ --output-manifest <local_path> \
+  --metadata-args '{"run_id":"test","component_name":"test_component", \
+  "artifact_bucket":"storied-landing-366912-kfp-output"}
+```
+
+## Hugging Face Datasets
+
+Run with the following commad:
+
+```
+python3 data_loading_hf_datasets.py --extra-args '{"project_id": "storied-landing-366912"}' \
  --output-manifest <local_path> \
   --metadata-args '{"run_id":"test","component_name":"test_component", \
   "artifact_bucket":"storied-landing-366912-kfp-output"}

--- a/examples/components/single_node/README.md
+++ b/examples/components/single_node/README.md
@@ -7,7 +7,7 @@ with the `poetry install` command from the root of the repository.
 
 ## Pandas
 
-Run with the following command:
+Run the following command to upload a Pandas dataframe to a Google Cloud Storage bucket:
 
 ```
 python3 data_loading_pandas.py --extra-args '{"project_id": "storied-landing-366912"}' \
@@ -18,7 +18,7 @@ python3 data_loading_pandas.py --extra-args '{"project_id": "storied-landing-366
 
 ## Hugging Face Datasets
 
-Run the following command to load a Hugging Face Dataset from the hub and upload it to a Google Cloud Storage bucket:
+Run the following command to load a Hugging Face Dataset from the [hub](https://huggingface.co/) and upload it to a Google Cloud Storage bucket:
 
 ```
 python3 data_loading_hf_datasets.py --extra-args '{"project_id": "soy-audio-379412"}' \

--- a/examples/components/single_node/README.md
+++ b/examples/components/single_node/README.md
@@ -7,22 +7,22 @@ with the `poetry install` command from the root of the repository.
 
 ## Pandas
 
-Run with the following commad:
+Run with the following command:
 
 ```
 python3 data_loading_pandas.py --extra-args '{"project_id": "storied-landing-366912"}' \
  --output-manifest <local_path> \
   --metadata-args '{"run_id":"test","component_name":"test_component", \
-  "artifact_bucket":"storied-landing-366912-kfp-output"}
+  "artifact_bucket":"storied-landing-366912-kfp-output"}'
 ```
 
 ## Hugging Face Datasets
 
-Run with the following commad:
+Run the following command to load a Hugging Face Dataset from the hub and upload it to a Google Cloud Storage bucket:
 
 ```
-python3 data_loading_hf_datasets.py --extra-args '{"project_id": "storied-landing-366912"}' \
+python3 data_loading_hf_datasets.py --extra-args '{"project_id": "soy-audio-379412"}' \
  --output-manifest <local_path> \
   --metadata-args '{"run_id":"test","component_name":"test_component", \
-  "artifact_bucket":"storied-landing-366912-kfp-output"}
+  "artifact_bucket":"soy-audio-379412_kfp-artifacts"}'
 ```

--- a/examples/components/single_node/data_loading_hf_datasets.py
+++ b/examples/components/single_node/data_loading_hf_datasets.py
@@ -1,0 +1,42 @@
+from typing import Optional, Dict, Union
+
+from datasets import load_dataset
+
+from express.components.hf_datasets_components import HFDatasetsLoaderComponent, HFDatasetsDatasetDraft
+from express.logger import configure_logging
+
+
+# pylint: disable=too-few-public-methods
+class SeedDatasetLoader(HFDatasetsLoaderComponent):
+    """Class that inherits from Hugging Face data loading """
+
+    @classmethod
+    def load(cls, extra_args: Optional[
+        Dict[str, Union[str, int, float, bool]]] = None) -> HFDatasetsDatasetDraft:
+        """
+        An example function showcasing the data loader component using Express functionalities
+        Args:
+            extra_args (Optional[Dict[str, Union[str, int, float, bool]]): optional args to pass to
+             the function (e.g. seed data source)
+        Returns:
+            HFDatasetsDatasetDraft: a dataset draft that creates a plan for an output datasets/manifest
+        """
+        configure_logging()
+        
+        # 1) Create example data source(s)
+        caption_dataset = load_dataset("lambdalabs/pokemon-blip-captions", split="train")
+
+        # 2) Create an example index
+        index_list = [f"image_{idx}" for idx in range(len(caption_dataset))]
+        caption_dataset.add_column(name="index", column=index_list)
+        
+        # 2.2) Create data_source dictionary
+        data_sources = {"captions": caption_dataset}
+        
+        # 3) Create dataset draft from index and additional data sources
+        dataset_draft = HFDatasetsDatasetDraft(index=index_list, data_sources=data_sources)
+        return dataset_draft
+
+
+if __name__ == '__main__':
+    SeedDatasetLoader.run()

--- a/examples/components/single_node/data_loading_hf_datasets.py
+++ b/examples/components/single_node/data_loading_hf_datasets.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, Union
 
-from datasets import load_dataset
+import pandas as pd
+from datasets import Dataset, load_dataset, concatenate_datasets
 
 from express.components.hf_datasets_components import HFDatasetsLoaderComponent, HFDatasetsDatasetDraft
 from express.logger import configure_logging
@@ -28,13 +29,16 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
 
         # 2) Create an example index
         index_list = [f"image_{idx}" for idx in range(len(caption_dataset))]
-        caption_dataset.add_column(name="index", column=index_list)
+        index_df = pd.DataFrame(index_list, columns=['index'])
+        index = Dataset.from_pandas(index_df)
+
+        caption_dataset = concatenate_datasets([index, caption_dataset])
         
         # 2.2) Create data_source dictionary
         data_sources = {"captions": caption_dataset}
         
         # 3) Create dataset draft from index and additional data sources
-        dataset_draft = HFDatasetsDatasetDraft(index=index_list, data_sources=data_sources)
+        dataset_draft = HFDatasetsDatasetDraft(index=index, data_sources=data_sources)
         return dataset_draft
 
 

--- a/examples/components/single_node/data_loading_pandas.py
+++ b/examples/components/single_node/data_loading_pandas.py
@@ -30,7 +30,7 @@ class SeedDatasetLoader(PandasLoaderComponent):
                     'size': [300, 400, 500, 600],
                     'format': ['jpeg', 'jpeg', 'jpeg', 'jpeg']}
         df_metadata = pd.DataFrame(metadata).set_index('index')
-        # 2.1.2) Caption]
+        # 2.1.2) Caption
         captions = {'index': index_list,
                     'captions': ['dog', 'cat', 'bear', 'duck']}
         df_captions = pd.DataFrame(captions).set_index('index')

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -52,7 +52,7 @@ class HFDatasetsDataset(ExpressDataset[List[str], Union[datasets.Dataset, datase
                 tmp_dir
             )
 
-            data_source_hf_datasets = load_dataset("parquet", data_dir=local_parquet_path)
+            data_source_hf_datasets = load_dataset("parquet", data_dir=local_parquet_path, split="train")
 
             if index_filter:
                 return data_source_hf_datasets.filter([index_filter])
@@ -70,7 +70,6 @@ class HFDatasetsDatasetHandler(ExpressDatasetHandler[List[str], datasets.Dataset
         with tempfile.TemporaryDirectory() as temp_folder:
             # TODO: uploading without writing to temp file
             # TODO: sharded parquet? not sure if we should shard the index or only the data sources
-            # HF shards by default
             dataset_path = f"{temp_folder}/{name}.parquet"
 
             data.to_parquet(path=dataset_path)

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -9,10 +9,11 @@ from typing import List, Optional, Dict, Union
 import datasets
 from datasets import load_dataset
 
+from express.manifest import DataManifest, DataSource, DataType
 from .common import ExpressDatasetHandler, ExpressDataset, ExpressTransformComponent, \
     ExpressDatasetDraft, ExpressLoaderComponent
 from express.storage_interface import StorageHandlerModule
-from express.manifest import DataManifest, DataSource, DataType
+
 
 # Define interface of pandas draft
 # pylint: disable=unsubscriptable-object

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -1,0 +1,132 @@
+"""Hugging Face Datasets single component module """
+
+import os
+import importlib
+import tempfile
+from abc import ABC, abstractmethod
+from typing import List, Optional, Dict, Union
+
+import datasets
+from datasets import load_dataset
+
+from .common import ExpressDatasetHandler, ExpressDataset, ExpressTransformComponent, \
+    ExpressDatasetDraft, ExpressLoaderComponent
+from express.storage_interface import StorageHandlerModule
+from express.manifest import DataManifest, DataSource, DataType
+
+# Define interface of pandas draft
+# pylint: disable=unsubscriptable-object
+HFDatasetsDatasetDraft = ExpressDatasetDraft[List[str], Union[pd.DataFrame, pd.Series]]
+
+# pylint: disable=no-member
+STORAGE_MODULE_PATH = StorageHandlerModule().to_dict()[os.environ.get('CLOUD_ENV', 'GCP')]
+STORAGE_HANDLER = importlib.import_module(STORAGE_MODULE_PATH).StorageHandler()
+
+
+# pylint: disable=too-few-public-methods
+class HFDatasetsDataset(ExpressDataset[List[str], Union[datasets.Dataset, datasets.DatasetDict]]):
+    """Hugging Face Datasets dataset"""
+
+    def load_index(self) -> datasets.Dataset:
+        """Function that loads in the index"""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            local_parquet_path = STORAGE_HANDLER.copy_file(self.manifest.index.location, tmp_dir)
+
+            dataset = load_dataset("parquet", data_files=local_parquet_path)
+
+            return dataset
+
+    @staticmethod
+    def _load_data_source(data_source: DataSource,
+                          index_filter: Union[datasets.Dataset, datasets.DatasetDict, List[str]]) -> Union[datasets.Dataset, datasets.DatasetDict]:
+        """Function that loads in a data source"""
+        if data_source.type != DataType.parquet:
+            raise TypeError("Only reading from parquet is currently supported.")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+
+            data_source_location = data_source.location
+
+            local_parquet_path = STORAGE_HANDLER.copy_parquet(
+                data_source_location,
+                tmp_dir
+            )
+
+            data_source_hf_datasets = load_dataset("parquet", data_dir=local_parquet_path)
+
+            if index_filter:
+                return data_source_hf_datasets.filter([index_filter])
+
+            return data_source_hf_datasets
+
+
+class HFDatasetsDatasetHandler(ExpressDatasetHandler[List[str], datasets.Dataset, datasets.DatasetDict]):
+    """Hugging Face Datasets Dataset handler"""
+
+    @staticmethod
+    def _upload_parquet(data: Union[datasets.Dataset, datasets.DatasetDict],
+                        name: str,
+                        remote_path: str) -> DataSource:
+        with tempfile.TemporaryDirectory() as temp_folder:
+            # TODO: uploading without writing to temp file
+            # TODO: sharded parquet? not sure if we should shard the index or only the data sources
+            # HF shards by default
+            dataset_path = f"{temp_folder}/{name}.parquet"
+
+            data.to_parquet(path=dataset_path)
+
+            fully_qualified_blob_path = f"{remote_path}/{name}.parquet"
+            STORAGE_HANDLER.copy_file(source_file=dataset_path,
+                                      destination=fully_qualified_blob_path)
+            return DataSource(
+                location=fully_qualified_blob_path,
+                type=DataType.parquet,
+                extensions=["parquet"],
+                n_files=1,
+                n_items=len(data)
+            )
+
+    @classmethod
+    def _upload_index(cls, index: Union[pd.DataFrame, pd.Series, pd.Index], remote_path: str) \
+            -> DataSource:
+        data_source = cls._upload_parquet(
+            data=index,
+            name='index',
+            remote_path=remote_path)
+        return data_source
+
+    @classmethod
+    def _upload_data_source(cls, name: str, data: Union[pd.DataFrame, pd.Series, pd.Index],
+                            remote_path: str) -> DataSource:
+        data_source = cls._upload_parquet(
+            data=data,
+            name=name,
+            remote_path=remote_path)
+        return data_source
+
+    @classmethod
+    def _load_dataset(cls, input_manifest: DataManifest) -> HFDatasetsDataset:
+        return HFDatasetsDataset(input_manifest)
+
+
+class HFDatasetsTransformComponent(HFDatasetsDatasetHandler,
+                               ExpressTransformComponent[List[str], datasets.Dataset], ABC):
+    """Hugging Face Datasets dataset transformer. Subclass this class to define custom transformation function"""
+
+    @classmethod
+    @abstractmethod
+    def transform(cls, data: HFDatasetsDataset,
+                  extra_args: Optional[
+                      Dict[str, Union[str, int, float, bool]]] = None) -> HFDatasetsDatasetDraft:
+        """Transform dataset"""
+
+
+class HFDatasetsLoaderComponent(HFDatasetsDatasetHandler, ExpressLoaderComponent[List[str], datasets.Dataset],
+                            ABC):
+    """Hugging Face Datasets dataset loader. Subclass this class to define custom transformation function"""
+
+    @classmethod
+    @abstractmethod
+    def load(cls, extra_args: Optional[Dict[str, Union[str, int, float, bool]]] = None) \
+            -> HFDatasetsDatasetDraft:
+        """Load initial dataset"""

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -89,15 +89,16 @@ class HFDatasetsDatasetHandler(ExpressDatasetHandler[List[str], datasets.Dataset
             # TODO: sharded parquet? not sure if we should shard the index or only the data sources
             dataset_path = f"{temp_folder}/{name}.parquet"
 
-            data.to_parquet(path=dataset_path)
+            data.to_parquet(path_or_buf=dataset_path)
 
             fully_qualified_blob_path = f"{remote_path}/{name}.parquet"
             STORAGE_HANDLER.copy_file(
                 source_file=dataset_path, destination=fully_qualified_blob_path
             )
+
             return DataSource(
                 location=fully_qualified_blob_path,
-                type=DataType.parquet,
+                type=DataType.PARQUET,
                 extensions=["parquet"],
                 n_files=1,
                 n_items=len(data),

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -77,9 +77,7 @@ class HFDatasetsDataset(
             return data_source_hf_datasets
 
 
-class HFDatasetsDatasetHandler(
-    ExpressDatasetHandler[List[str], datasets.Dataset, datasets.DatasetDict]
-):
+class HFDatasetsDatasetHandler(ExpressDatasetHandler[List[str], datasets.Dataset]):
     """Hugging Face Datasets Dataset handler"""
 
     @staticmethod

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -9,52 +9,66 @@ from typing import List, Optional, Dict, Union
 import datasets
 from datasets import load_dataset
 
-from express.manifest import DataManifest, DataSource, DataType
-from .common import ExpressDatasetHandler, ExpressDataset, ExpressTransformComponent, \
-    ExpressDatasetDraft, ExpressLoaderComponent
 from express.storage_interface import StorageHandlerModule
+from express.manifest import DataManifest, DataSource, DataType
+from .common import (
+    ExpressDatasetHandler,
+    ExpressDataset,
+    ExpressTransformComponent,
+    ExpressDatasetDraft,
+    ExpressLoaderComponent,
+)
 
 
 # Define interface of pandas draft
 # pylint: disable=unsubscriptable-object
-HFDatasetsDatasetDraft = ExpressDatasetDraft[List[str], Union[pd.DataFrame, pd.Series]]
+HFDatasetsDatasetDraft = ExpressDatasetDraft[List[str], datasets.Dataset]
 
 # pylint: disable=no-member
-STORAGE_MODULE_PATH = StorageHandlerModule().to_dict()[os.environ.get('CLOUD_ENV', 'GCP')]
+STORAGE_MODULE_PATH = StorageHandlerModule().to_dict()[
+    os.environ.get("CLOUD_ENV", "GCP")
+]
 STORAGE_HANDLER = importlib.import_module(STORAGE_MODULE_PATH).StorageHandler()
 
 
 # pylint: disable=too-few-public-methods
-class HFDatasetsDataset(ExpressDataset[List[str], Union[datasets.Dataset, datasets.DatasetDict]]):
+class HFDatasetsDataset(
+    ExpressDataset[List[str], Union[datasets.Dataset, datasets.DatasetDict]]
+):
     """Hugging Face Datasets dataset"""
 
     def load_index(self) -> datasets.Dataset:
         """Function that loads in the index"""
         with tempfile.TemporaryDirectory() as tmp_dir:
-            local_parquet_path = STORAGE_HANDLER.copy_file(self.manifest.index.location, tmp_dir)
+            local_parquet_path = STORAGE_HANDLER.copy_file(
+                self.manifest.index.location, tmp_dir
+            )
 
             # we specify "train" here to get a `Dataset` instead of a `DatasetDict`
-            dataset = load_dataset("parquet", data_files=local_parquet_path, split="train")
+            dataset = load_dataset(
+                "parquet", data_files=local_parquet_path, split="train"
+            )
 
             return dataset
 
     @staticmethod
-    def _load_data_source(data_source: DataSource,
-                          index_filter: datasets.Dataset) -> Union[datasets.Dataset, datasets.DatasetDict]:
+    def _load_data_source(
+        data_source: DataSource, index_filter: datasets.Dataset
+    ) -> Union[datasets.Dataset, datasets.DatasetDict]:
         """Function that loads in a data source"""
         if data_source.type != DataType.parquet:
             raise TypeError("Only reading from parquet is currently supported.")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-
             data_source_location = data_source.location
 
             local_parquet_path = STORAGE_HANDLER.copy_parquet(
-                data_source_location,
-                tmp_dir
+                data_source_location, tmp_dir
             )
 
-            data_source_hf_datasets = load_dataset("parquet", data_dir=local_parquet_path)
+            data_source_hf_datasets = load_dataset(
+                "parquet", data_dir=local_parquet_path
+            )
 
             if index_filter:
                 index = index_filter["index"]
@@ -63,13 +77,15 @@ class HFDatasetsDataset(ExpressDataset[List[str], Union[datasets.Dataset, datase
             return data_source_hf_datasets
 
 
-class HFDatasetsDatasetHandler(ExpressDatasetHandler[List[str], datasets.Dataset, datasets.DatasetDict]):
+class HFDatasetsDatasetHandler(
+    ExpressDatasetHandler[List[str], datasets.Dataset, datasets.DatasetDict]
+):
     """Hugging Face Datasets Dataset handler"""
 
     @staticmethod
-    def _upload_parquet(data: Union[datasets.Dataset, datasets.DatasetDict],
-                        name: str,
-                        remote_path: str) -> DataSource:
+    def _upload_parquet(
+        data: Union[datasets.Dataset, datasets.DatasetDict], name: str, remote_path: str
+    ) -> DataSource:
         with tempfile.TemporaryDirectory() as temp_folder:
             # TODO: uploading without writing to temp file
             # TODO: sharded parquet? not sure if we should shard the index or only the data sources
@@ -78,32 +94,32 @@ class HFDatasetsDatasetHandler(ExpressDatasetHandler[List[str], datasets.Dataset
             data.to_parquet(path=dataset_path)
 
             fully_qualified_blob_path = f"{remote_path}/{name}.parquet"
-            STORAGE_HANDLER.copy_file(source_file=dataset_path,
-                                      destination=fully_qualified_blob_path)
+            STORAGE_HANDLER.copy_file(
+                source_file=dataset_path, destination=fully_qualified_blob_path
+            )
             return DataSource(
                 location=fully_qualified_blob_path,
                 type=DataType.parquet,
                 extensions=["parquet"],
                 n_files=1,
-                n_items=len(data)
+                n_items=len(data),
             )
 
     @classmethod
-    def _upload_index(cls, index: datasets.Dataset, remote_path: str) \
-            -> DataSource:
+    def _upload_index(cls, index: datasets.Dataset, remote_path: str) -> DataSource:
         data_source = cls._upload_parquet(
-            data=index,
-            name='index',
-            remote_path=remote_path)
+            data=index, name="index", remote_path=remote_path
+        )
         return data_source
 
     @classmethod
-    def _upload_data_source(cls, name: str, data: Union[datasets.Dataset, datasets.DatasetDict],
-                            remote_path: str) -> DataSource:
-        data_source = cls._upload_parquet(
-            data=data,
-            name=name,
-            remote_path=remote_path)
+    def _upload_data_source(
+        cls,
+        name: str,
+        data: Union[datasets.Dataset, datasets.DatasetDict],
+        remote_path: str,
+    ) -> DataSource:
+        data_source = cls._upload_parquet(data=data, name=name, remote_path=remote_path)
         return data_source
 
     @classmethod
@@ -111,24 +127,35 @@ class HFDatasetsDatasetHandler(ExpressDatasetHandler[List[str], datasets.Dataset
         return HFDatasetsDataset(input_manifest)
 
 
-class HFDatasetsTransformComponent(HFDatasetsDatasetHandler,
-                               ExpressTransformComponent[List[str], datasets.Dataset], ABC):
-    """Hugging Face Datasets dataset transformer. Subclass this class to define custom transformation function"""
+class HFDatasetsTransformComponent(
+    HFDatasetsDatasetHandler,
+    ExpressTransformComponent[List[str], datasets.Dataset],
+    ABC,
+):
+    """
+    Hugging Face Datasets dataset transformer. Subclass this class to define custom
+    transformation function
+    """
 
     @classmethod
     @abstractmethod
-    def transform(cls, data: HFDatasetsDataset,
-                  extra_args: Optional[
-                      Dict[str, Union[str, int, float, bool]]] = None) -> HFDatasetsDatasetDraft:
+    def transform(
+        cls,
+        data: HFDatasetsDataset,
+        extra_args: Optional[Dict[str, Union[str, int, float, bool]]] = None,
+    ) -> HFDatasetsDatasetDraft:
         """Transform dataset"""
 
 
-class HFDatasetsLoaderComponent(HFDatasetsDatasetHandler, ExpressLoaderComponent[List[str], datasets.Dataset],
-                            ABC):
-    """Hugging Face Datasets dataset loader. Subclass this class to define custom transformation function"""
+class HFDatasetsLoaderComponent(
+    HFDatasetsDatasetHandler, ExpressLoaderComponent[List[str], datasets.Dataset], ABC
+):
+    """Hugging Face Datasets dataset loader. Subclass this class to define custom
+    transformation function"""
 
     @classmethod
     @abstractmethod
-    def load(cls, extra_args: Optional[Dict[str, Union[str, int, float, bool]]] = None) \
-            -> HFDatasetsDatasetDraft:
+    def load(
+        cls, extra_args: Optional[Dict[str, Union[str, int, float, bool]]] = None
+    ) -> HFDatasetsDatasetDraft:
         """Load initial dataset"""

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -22,7 +22,7 @@ class DataType(str, Enum):
     def is_valid(cls, data_type: str) -> bool:
         """Check if data type is valid"""
         # pylint: disable=no-member
-        return data_type in cls._member_names_
+        return data_type in cls.__members__.values()
 
 
 @dataclass

--- a/license_strategy.ini
+++ b/license_strategy.ini
@@ -26,5 +26,14 @@ authorized_licenses:
   3-clause BSD
   new BSD
   MIT
+  GNU Library or Lesser General Public License (LGPL)
+  GNU Lesser General Public License v2 (LGPLv2)
+  GNU Lesser General Public License v2 or later (LGPLv2+)
+  GNU Lesser General Public License v3 (LGPLv3)
+  GNU Lesser General Public License v3 or later (LGPLv3+)
+  Mozilla Public License 1.0 (MPL)
+  Mozilla Public License 1.1 (MPL 1.1)
+  Mozilla Public License 2.0 (MPL 2.0)
+  The Unlicense (Unlicense)
 
 [Authorized Packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
 python = "^3.8"
 dataclasses-json = "^0.5.7"
 pandas = "^1.3.5"
+datasets = "2.10.1"
 
 [tool.poetry.group.test.dependencies]
 liccheck = "^0.7.3"


### PR DESCRIPTION
This PR adds boilerplate `HFDatasetLoaderComponent` and `HFDatasetTransformComponent` classes.

Questions:
- in the Datasets library, there's a distinction between a `Dataset` and a `DatasetDict`. The latter is just a dictionary of several `Dataset` instances, with keys like "train", "validation", "test". I assume the index could be stored as a `Dataset`, whereas data sources can be either a `Dataset` or a `DatasetDict`.
- if you use [`load_dataset`](https://huggingface.co/docs/datasets/v2.10.0/en/package_reference/loading_methods#datasets.load_dataset) without providing a split (like "train", "validation"), this method returns a `DatasetDict` instead of a `Dataset`. So was wondering how we could handle these splits a user might have.

To do:

- [ ] add an example