### PR TITLE
Add isort to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,11 @@ repos:
             "-sn", # Don't display the score
             "--disable=fixme"
           ]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        name: bandit
+        types: [python]
+        files: "^express/"
+        args: ["-f", "custom", "-q"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
             "-sn", # Don't display the score
             "--disable=fixme"
           ]
+
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:
@@ -24,3 +25,10 @@ repos:
         types: [python]
         files: "^express/"
         args: ["-f", "custom", "-q"]
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        name: black
+        files: "^express/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,11 @@ repos:
       - id: black
         name: black
         files: "^express/"
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort
+        files: "^express/"
+        args: ["--project", "express"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         args: ["-f", "custom", "-q"]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
         name: black

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -3,13 +3,13 @@ This file is the entrypoint of the component. It will parse all arguments
 and give them to the actual core of the component.
 """
 import argparse
+import importlib
 import json
 import os
-import importlib
-from datetime import datetime
 from abc import ABC, abstractmethod
+from datetime import datetime
 from pathlib import Path
-from typing import Dict, Optional, TypeVar, Generic, Union
+from typing import Dict, Generic, Optional, TypeVar, Union
 
 from express.manifest import DataManifest, DataSource, Metadata
 from express.storage_interface import StorageHandlerModule

--- a/express/components/pandas_components.py
+++ b/express/components/pandas_components.py
@@ -1,19 +1,19 @@
 """Pandas single component module """
 
-import os
 import importlib
+import os
 import tempfile
 from abc import ABC, abstractmethod
-from typing import List, Optional, Dict, Union
+from typing import Dict, List, Optional, Union
 
 import pandas as pd
 
 from express.components.common import (
-    ExpressDatasetHandler,
     ExpressDataset,
-    ExpressTransformComponent,
     ExpressDatasetDraft,
+    ExpressDatasetHandler,
     ExpressLoaderComponent,
+    ExpressTransformComponent,
 )
 from express.manifest import DataManifest, DataSource, DataType
 from express.storage_interface import StorageHandlerModule

--- a/express/gcp_storage.py
+++ b/express/gcp_storage.py
@@ -1,6 +1,7 @@
 """
 General helper class to handle gcp storage functionalities
 """
+import io
 import subprocess  # nosec
 import os
 import logging

--- a/express/gcp_storage.py
+++ b/express/gcp_storage.py
@@ -1,7 +1,6 @@
 """
 General helper class to handle gcp storage functionalities
 """
-import io
 import subprocess  # nosec
 import os
 import logging
@@ -26,12 +25,12 @@ class StorageHandler(StorageHandlerInterface):
               containing the blob of interest
         Returns:
             DecodedBlobPath: a dataclass containing the bucket and blob path name
-         """
+        """
         parsed_url = urlparse(fully_qualified_blob_path)
-        if parsed_url.scheme == 'gs':
+        if parsed_url.scheme == "gs":
             bucket, blob_path = parsed_url.hostname, parsed_url.path[1:]
         else:
-            path = parsed_url.path[1:].split('/', 1)
+            path = parsed_url.path[1:].split("/", 1)
             bucket, blob_path = path[0], path[1]
 
         return DecodedBlobPath(bucket, blob_path)
@@ -45,7 +44,7 @@ class StorageHandler(StorageHandlerInterface):
             blob_path (str): the blob path
         Returns
             str: the fully qualified blob path
-         """
+        """
 
         return f"gs://{bucket}/{blob_path}"
 
@@ -59,13 +58,22 @@ class StorageHandler(StorageHandlerInterface):
         Returns:
             List [str]: the list of blobs
         """
-        blob_list = subprocess.run(["gsutil", "ls", fully_qualified_blob_path],  # nosec
-                                   capture_output=True, check=True).stdout.decode().split('\n')
+        blob_list = (
+            subprocess.run(  # nosec
+                ["gsutil", "ls", fully_qualified_blob_path],
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .split("\n")
+        )
 
         return blob_list
 
     @staticmethod
-    def copy_folder(source: str, destination: str, copy_source_content: bool = False) -> str:
+    def copy_folder(
+        source: str, destination: str, copy_source_content: bool = False
+    ) -> str:
         """
         Function that copies a source folder (or blob) from a remote/local source to a local/remote
         location respectively
@@ -84,8 +92,19 @@ class StorageHandler(StorageHandlerInterface):
                 source = f"{source}*"
 
         subprocess.run(  # nosec
-            ["gsutil", '-o', '"GSUtil:use_gcloud_storage=True"', '-q', "-m", "cp", "-r",
-             source, destination], check=True)
+            [
+                "gsutil",
+                "-o",
+                '"GSUtil:use_gcloud_storage=True"',
+                "-q",
+                "-m",
+                "cp",
+                "-r",
+                source,
+                destination,
+            ],
+            check=True,
+        )
 
         logger.info("Copying folder from %s to %s [DONE]", source, destination)
 
@@ -104,12 +123,23 @@ class StorageHandler(StorageHandlerInterface):
             destination (str): the destination blob/folder to copy the files to
         """
         with subprocess.Popen(  # nosec
-            ['gsutil', '-o', '"GSUtil:use_gcloud_storage=True"', '-q', '-m', 'cp', '-I',
-             destination], stdin=subprocess.PIPE
+            [
+                "gsutil",
+                "-o",
+                '"GSUtil:use_gcloud_storage=True"',
+                "-q",
+                "-m",
+                "cp",
+                "-I",
+                destination,
+            ],
+            stdin=subprocess.PIPE,
         ) as gsutil_copy:
             gsutil_copy.communicate(b"\n".join([f.encode() for f in source_files]))
 
-        logger.info("A total of %s files were copied to %s", len(source_files), destination)
+        logger.info(
+            "A total of %s files were copied to %s", len(source_files), destination
+        )
 
     def copy_file(self, source_file: str, destination: str) -> str:
         """

--- a/express/gcp_storage.py
+++ b/express/gcp_storage.py
@@ -1,14 +1,14 @@
 """
 General helper class to handle gcp storage functionalities
 """
-import subprocess  # nosec
-import os
 import logging
+import os
+import subprocess  # nosec
 from typing import List
 from urllib.parse import urlparse
 
-from express.storage_interface import StorageHandlerInterface, DecodedBlobPath
 from express import io
+from express.storage_interface import DecodedBlobPath, StorageHandlerInterface
 
 logger = logging.getLogger(__name__)
 

--- a/express/io.py
+++ b/express/io.py
@@ -1,9 +1,9 @@
 """
 General I/O helpers function
 """
-import pathlib
 import logging
 import os
+import pathlib
 
 logger = logging.getLogger(__name__)
 

--- a/express/logger.py
+++ b/express/logger.py
@@ -18,5 +18,6 @@ def configure_logging() -> None:
     # logging stdout handler
     handler = logging.StreamHandler(stream=sys.stdout)
     handler.setFormatter(
-        logging.Formatter(fmt='[%(asctime)s | %(name)s | %(levelname)s] %(message)s'))
+        logging.Formatter(fmt="[%(asctime)s | %(name)s | %(levelname)s] %(message)s")
+    )
     logger.addHandler(handler)

--- a/express/logger.py
+++ b/express/logger.py
@@ -1,8 +1,8 @@
 """Utils file with useful methods."""
 
 import logging
-import sys
 import os
+import sys
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", default="INFO")
 

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -14,8 +14,9 @@ class DataType(str, Enum):
     """
     Supported types for stored data.
     """
-    PARQUET = 'parquet'
-    BLOB = 'blob'
+
+    PARQUET = "parquet"
+    BLOB = "blob"
 
     @classmethod
     def is_valid(cls, data_type: str) -> bool:
@@ -36,6 +37,7 @@ class DataSource:
         n_items (int): how many items (e.g. distinct images, captions, etc.) are covered by the
          data.
     """
+
     location: str
     type: DataType
     extensions: List[str]
@@ -62,6 +64,7 @@ class Metadata:
         creation_date (str): the creation date of the manifest
         num_items (int): total number of rows in the index
     """
+
     # TODO: get rid of defaults
     artifact_bucket: str = field(default_factory=str)
     run_id: str = field(default_factory=str)
@@ -85,17 +88,23 @@ class DataManifest:
         metadata (Metadata): The metadata associated with the manifest
 
     """
+
     index: DataSource
     data_sources: Dict[str, DataSource] = field(default_factory=dict)
-    metadata: Metadata = field(default_factory=Metadata)  # TODO: make mandatory during construction
+    metadata: Metadata = field(
+        default_factory=Metadata
+    )  # TODO: make mandatory during construction
 
     def __post_init__(self):
-        if (self.index.type != DataType.PARQUET) or (not DataType.is_valid(self.index.type)):
+        if (self.index.type != DataType.PARQUET) or (
+            not DataType.is_valid(self.index.type)
+        ):
             raise TypeError("Index needs to be of type 'parquet'.")
         for name, dataset in self.data_sources.items():
             if not DataType.is_valid(dataset.type):
                 raise TypeError(
-                    f"Data type '{dataset.type}' for data source '{name}' is not valid.")
+                    f"Data type '{dataset.type}' for data source '{name}' is not valid."
+                )
 
     @classmethod
     def from_path(cls, manifest_path):

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -5,7 +5,7 @@ components of the pipeline
 import json
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Dict
+from typing import Dict, List
 
 from dataclasses_json import dataclass_json
 

--- a/express/storage_interface.py
+++ b/express/storage_interface.py
@@ -13,6 +13,7 @@ from dataclasses_json import dataclass_json
 @dataclass
 class StorageHandlerModule:
     """Datclass to define module path for the different cloud Storage Handlers"""
+
     # pylint: disable=invalid-name
     GCP: str = "express.gcp_storage"
     AWS: str = "express.aws_storage"
@@ -23,6 +24,7 @@ class StorageHandlerModule:
 @dataclass
 class DecodedBlobPath:
     """Dataclass for blob path construct"""
+
     bucket_name: str
     blob_path: str
 
@@ -42,7 +44,7 @@ class StorageHandlerInterface(ABC):
          Args:
          fully_qualified_blob_path (str): the fully qualified blob path that points to the blob
             containing the blob of interest
-         """
+        """
 
     @staticmethod
     @abstractmethod
@@ -54,7 +56,7 @@ class StorageHandlerInterface(ABC):
             blob_path (str): the blob path
         Returns
             str: the fully qualified blob path
-         """
+        """
 
     @staticmethod
     @abstractmethod
@@ -70,7 +72,9 @@ class StorageHandlerInterface(ABC):
 
     @staticmethod
     @abstractmethod
-    def copy_folder(source: str, destination: str, copy_source_content: bool = False) -> str:
+    def copy_folder(
+        source: str, destination: str, copy_source_content: bool = False
+    ) -> str:
         """
         Function that copies a source folder (or blob) from a remote/local source to a local/remote
         location respectively
@@ -119,12 +123,8 @@ class StorageHandlerInterface(ABC):
             str: the path where the parquet file/folder was copied to
         """
         if ".parquet" in parquet_path:
-            local_parquet_path = self.copy_file(
-                parquet_path,
-                destination)
+            local_parquet_path = self.copy_file(parquet_path, destination)
         else:
-            local_parquet_path = self.copy_folder(
-                parquet_path,
-                destination)
+            local_parquet_path = self.copy_folder(parquet_path, destination)
 
         return local_parquet_path

--- a/express/storage_interface.py
+++ b/express/storage_interface.py
@@ -3,8 +3,8 @@ General interface class to unify storage functions across different cloud enviro
 """
 
 from abc import ABC, abstractmethod
-from typing import List
 from dataclasses import dataclass
+from typing import List
 
 from dataclasses_json import dataclass_json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,9 @@ dataclasses-json = "^0.5.7"
 pandas = "^1.3.5"
 
 [tool.poetry.group.test.dependencies]
-bandit = { version = "^1.7.4", extras = ["toml"] }
 liccheck = "^0.7.3"
 pylint = "2.16.4"
 pre-commit = "^3.1.1"
-
-[tool.bandit]
-exclude_dirs = ["*/mlpipelines/components/sd_finetuning_component/src/train_text_to_image.py"]
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,6 @@ pre-commit = "^3.1.1"
 [build-system]
 requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
> isort your imports, so you don't have to.
> 
> isort is a Python utility / library to sort imports alphabetically, and automatically separated into sections and by type.