### PR TITLE
Switch pylint for Ruff

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -27,3 +27,9 @@ jobs:
         run: |
           poetry export -f requirements.txt --output /tmp/requirements.txt
           poetry run liccheck -s license_strategy.ini -r /tmp/requirements.txt -l PARANOID
+      - name: Shadow-run pylint
+        # Check if pylint catches errors not caught by our pre-commit checks to validate switch
+        # to ruff
+        run: |
+          pip install pylint==2.16.4
+          pylint express --exit-zero

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,13 @@ ci:
   autoupdate_branch: "main"
   autoupdate_schedule: monthly
 repos:
-  - repo: local
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.254'
     hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
-        files:  |
-            (?x)^(
-                express/.*|
-                tests/.*|
-            )$
-        args:
-          [
-            "-rn", # Only display messages
-            "-sn", # Don't display the score
-            "--disable=fixme"
-          ]
+      - id: ruff
+        files: "^express/"
+        args: [--fix, --exit-non-zero-on-fix]
+
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4

--- a/express/components/__init__.py
+++ b/express/components/__init__.py
@@ -1,3 +1,3 @@
 """Module holding base components to build on."""
 
-from .pandas_components import PandasLoaderComponent, PandasTransformComponent
+from .pandas_components import PandasLoaderComponent, PandasTransformComponent  # noqa

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -14,7 +14,6 @@ from typing import Dict, Optional, TypeVar, Generic, Union
 from express.manifest import DataManifest, DataSource, Metadata
 from express.storage_interface import StorageHandlerModule
 
-# pylint: disable=no-member
 STORAGE_MODULE_PATH = StorageHandlerModule().to_dict()[
     os.environ.get("CLOUD_ENV", "GCP")
 ]
@@ -182,7 +181,6 @@ class ExpressDatasetDraft(ABC, Generic[IndexT, DataT]):
         return self
 
 
-# pylint: disable=too-few-public-methods
 class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
     """
     Abstract mixin class to read from and write to Express Datasets.

--- a/express/components/pandas_components.py
+++ b/express/components/pandas_components.py
@@ -19,17 +19,14 @@ from express.manifest import DataManifest, DataSource, DataType
 from express.storage_interface import StorageHandlerModule
 
 # Define interface of pandas draft
-# pylint: disable=unsubscriptable-object
 PandasDatasetDraft = ExpressDatasetDraft[List[str], Union[pd.DataFrame, pd.Series]]
 
-# pylint: disable=no-member
 STORAGE_MODULE_PATH = StorageHandlerModule().to_dict()[
     os.environ.get("CLOUD_ENV", "GCP")
 ]
 STORAGE_HANDLER = importlib.import_module(STORAGE_MODULE_PATH).StorageHandler()
 
 
-# pylint: disable=too-few-public-methods
 class PandasDataset(ExpressDataset[List[str], Union[pd.DataFrame, pd.Series]]):
     """Pandas dataset"""
 

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -21,7 +21,6 @@ class DataType(str, Enum):
     @classmethod
     def is_valid(cls, data_type: str) -> bool:
         """Check if data type is valid"""
-        # pylint: disable=no-member
         return data_type in cls._member_names_
 
 
@@ -45,7 +44,6 @@ class DataSource:
     n_items: int = field(default_factory=int)
 
 
-# pylint: disable=too-few-public-methods, too-many-instance-attributes
 @dataclass_json
 @dataclass
 class Metadata:
@@ -111,5 +109,4 @@ class DataManifest:
         """Load data manifest from a given manifest path"""
         with open(manifest_path, encoding="utf-8") as file_:
             manifest_load = json.load(file_)
-            # pylint: disable=no-member
             return DataManifest.from_dict(manifest_load)

--- a/express/storage_interface.py
+++ b/express/storage_interface.py
@@ -14,7 +14,6 @@ from dataclasses_json import dataclass_json
 class StorageHandlerModule:
     """Datclass to define module path for the different cloud Storage Handlers"""
 
-    # pylint: disable=invalid-name
     GCP: str = "express.gcp_storage"
     AWS: str = "express.aws_storage"
     AZURE: str = "express.azure_storage"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,12 @@ pandas = "^1.3.5"
 
 [tool.poetry.group.test.dependencies]
 liccheck = "^0.7.3"
-pylint = "2.16.4"
 pre-commit = "^3.1.1"
 pytest= "^7.2.2"
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 100  # Only for comments, as code is handled by black at length 88


### PR DESCRIPTION
Based on [Niels' suggestion](https://github.com/ml6team/express/pull/11#issuecomment-1461521485).

Ruff is a lot faster than Pylint and an also prevents the need for isort. While it [doesn't completely cover all pylint checks](https://github.com/charliermarsh/ruff/issues/970), a lot of the non-covered issues will be covered by bandit or mypy (still to add) instead.
