### PR TITLE
Add sanity check

### DIFF
--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -30,7 +30,9 @@ class HFDatasetsDatasetDraft(ExpressDatasetDraft[List[str], datasets.Dataset]):
     def _is_sublist(self, list1, list2):
         return set(list1) <= set(list2)
 
-    def sanity_check(self, index: datasets.Dataset, data_sources: dict) -> bool:
+    def sanity_check(
+        self, index: Optional[datasets.Dataset] = None, data_sources: dict = None
+    ) -> bool:
         if len(data_sources) == 0 or index is None:
             return True
         else:


### PR DESCRIPTION
This PR adds logic to verify that, when creating an output manifest, all data sources have an index and share data for (at least) the same index. Each framework (like HuggingFace datassets, Pandas, etc) needs to implement this.