### PR TITLE
Feature/simplify metadata argument passing

### DIFF
--- a/examples/components/single_node/hf_datasets/README.MD
+++ b/examples/components/single_node/hf_datasets/README.MD
@@ -5,8 +5,8 @@
 Run the following command to load a Hugging Face Dataset from the [hub](https://huggingface.co/) and upload it to a Google Cloud Storage bucket:
 
 ```
-python3 data_loading_hf_datasets.py --extra-args '{"project_id": "soy-audio-379412"}' \
- --output-manifest <local_path> \
-  --metadata-args '{"run_id":"test","component_name":"test_component", \
-  "artifact_bucket":"soy-audio-379412_kfp-artifacts"}'
+python3 data_loading_hf_datasets.py \
+--args '{"project_id": "soy-audio-379412", "run_id":"test","component_name":"test_component", \
+  "artifact_bucket":"soy-audio-379412_kfp-artifacts"}' \
+--output-manifest <local_path>
 ```

--- a/examples/components/single_node/hf_datasets/data_loading_hf_datasets.py
+++ b/examples/components/single_node/hf_datasets/data_loading_hf_datasets.py
@@ -1,9 +1,10 @@
-from typing import Optional, Dict, Union
+from typing import Dict, Union
 
 import pandas as pd
 from datasets import Dataset, load_dataset, concatenate_datasets
 
-from express.components.hf_datasets_components import HFDatasetsLoaderComponent, HFDatasetsDatasetDraft
+from express.components.hf_datasets_components import HFDatasetsLoaderComponent, \
+    HFDatasetsDatasetDraft
 from express.logger import configure_logging
 
 
@@ -12,18 +13,19 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
     """Class that inherits from Hugging Face data loading """
 
     @classmethod
-    def load(cls, extra_args: Optional[
-        Dict[str, Union[str, int, float, bool]]] = None) -> HFDatasetsDatasetDraft:
+    def load(cls,
+             args: Dict[str, Union[str, int, float, bool]] = None) -> HFDatasetsDatasetDraft:
         """
         An example function showcasing the data loader component using Express functionalities
         Args:
-            extra_args (Optional[Dict[str, Union[str, int, float, bool]]): optional args to pass to
-             the function (e.g. seed data source)
+            args ([Dict[str, Union[str, int, float, bool]]): Component arguments passed as a
+             json dict string
         Returns:
-            HFDatasetsDatasetDraft: a dataset draft that creates a plan for an output datasets/manifest
+            HFDatasetsDatasetDraft: a dataset draft that creates a plan for an output
+             datasets/manifest
         """
         configure_logging()
-        
+
         # 1) Create example data source(s)
         caption_dataset = load_dataset("lambdalabs/pokemon-blip-captions", split="train")
 
@@ -33,10 +35,10 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
         index = Dataset.from_pandas(index_df)
 
         caption_dataset = concatenate_datasets([index, caption_dataset])
-        
+
         # 2.2) Create data_source dictionary
         data_sources = {"captions": caption_dataset}
-        
+
         # 3) Create dataset draft from index and additional data sources
         dataset_draft = HFDatasetsDatasetDraft(index=index, data_sources=data_sources)
         return dataset_draft

--- a/examples/components/single_node/pandas/README.MD
+++ b/examples/components/single_node/pandas/README.MD
@@ -5,8 +5,7 @@
 Run the following command to upload a Pandas dataframe to a Google Cloud Storage bucket:
 
 ```
-python3 data_loading_pandas.py --extra-args '{"project_id": "storied-landing-366912"}' \
- --output-manifest <local_path> \
-  --metadata-args '{"run_id":"test","component_name":"test_component", \
-  "artifact_bucket":"storied-landing-366912-kfp-output"}'
+--args '{"project_id": "soy-audio-379412", "run_id":"test","component_name":"test_component", \
+  "artifact_bucket":"soy-audio-379412_kfp-artifacts"}' \
+--output-manifest <local_path>
 ```

--- a/examples/components/single_node/pandas/data_loading_pandas.py
+++ b/examples/components/single_node/pandas/data_loading_pandas.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Union
+from typing import Dict, Union
 import pandas as pd
 
 from express.components.pandas_components import PandasLoaderComponent, PandasDatasetDraft
@@ -10,13 +10,12 @@ class SeedDatasetLoader(PandasLoaderComponent):
     """Class that inherits from Pandas data loading """
 
     @classmethod
-    def load(cls, extra_args: Optional[
-        Dict[str, Union[str, int, float, bool]]] = None) -> PandasDatasetDraft:
+    def load(cls, args: Dict[str, Union[str, int, float, bool]] = None) -> PandasDatasetDraft:
         """
         An example function showcasing the data loader component using Express functionalities
         Args:
-            extra_args (Optional[Dict[str, Union[str, int, float, bool]]): optional args to pass to
-             the function (e.g. seed data source)
+            args ([Dict[str, Union[str, int, float, bool]]): Component arguments passed as a
+             json dict string
         Returns:
             PandasDatasetDraft: a dataset draft that creates a plan for an output datasets/manifest
         """

--- a/examples/pipelines/hf_dataset_pipeline/components/add_captions/Dockerfile
+++ b/examples/pipelines/hf_dataset_pipeline/components/add_captions/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.8-slim
+FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
+
+# Set the working directory to the source folder
+WORKDIR /src
 
 ## System dependencies
 RUN apt-get update && \
@@ -17,15 +20,12 @@ RUN mkdir -p /usr/local/gcloud \
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # install requirements
-COPY requirements.txt /
+COPY ./requirements.txt /src/requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Copy over src-files of the component
 COPY src /src
 
-# TODO: ADD EXTRA FILES HERE IF NEEDED!
 
-# Set the working directory to the source folder
-WORKDIR /src
 
 ENTRYPOINT ["python", "main.py"]

--- a/examples/pipelines/hf_dataset_pipeline/components/add_captions/README.md
+++ b/examples/pipelines/hf_dataset_pipeline/components/add_captions/README.md
@@ -1,10 +1,10 @@
 This component can be run as follows:
 
 ```
-python3 main.py --extra-args '{"dataset_name": "lambdalabs/pokemon-blip-captions"}' \
- --output-manifest <local_path> \
-  --metadata-args '{"run_id":"test","component_name":"test_component", \
-  "artifact_bucket":"soy-audio-379412_kfp-artifacts"}'
+python3 main.py \
+--args '{"dataset_name": "lambdalabs/pokemon-blip-captions",
+ "run_id":"test","component_name":"test_component","artifact_bucket":"soy-audio-379412_kfp-artifacts"}' \
+ --output-manifest <local_path> 
 ```
 
 To build the Docker image, simply run:

--- a/examples/pipelines/hf_dataset_pipeline/components/add_captions/component.yaml
+++ b/examples/pipelines/hf_dataset_pipeline/components/add_captions/component.yaml
@@ -2,7 +2,7 @@ name: add_captions
 description: A basic component that takes a dataset name from the 🤗 hub as input and uploads it to a GCS bucket.
 inputs: 
     - name: args
-      description: Additional arguments passed to the component, as a json dict string
+      description: Component arguments passed as a json dict string
       type: String
     
     - name: input_manifest

--- a/examples/pipelines/hf_dataset_pipeline/components/add_captions/component.yaml
+++ b/examples/pipelines/hf_dataset_pipeline/components/add_captions/component.yaml
@@ -1,14 +1,10 @@
-name: load_from_hub
+name: add_captions
 description: A basic component that takes a dataset name from the 🤗 hub as input and uploads it to a GCS bucket.
 inputs: 
-    - name: extra_args
+    - name: args
       description: Additional arguments passed to the component, as a json dict string
       type: String
     
-    - name: metadata
-      description: Metadata arguments, passed as a json dict string
-      type: String
-
     - name: input_manifest
       description: Path to the input manifest
       type: String
@@ -23,7 +19,6 @@ implementation:
         command: [
             python3, main.py,
             --input-manifest,       {inputPath: input_manifest},
-            --metadata,             {inputValue: metadata},
-            --extra-args,           {inputValue: extra_args},
+            --args,                 {inputValue: args},
             --output-manifest,      {outputPath: output_manifest},
         ]

--- a/examples/pipelines/hf_dataset_pipeline/components/add_captions/requirements.txt
+++ b/examples/pipelines/hf_dataset_pipeline/components/add_captions/requirements.txt
@@ -1,6 +1,4 @@
-# Add component requirements here
-git+https://github.com/ml6team/express.git@main
-datasets
-transformers
-torch
-Pillow
+git+https://github.com/ml6team/express.git@27957bb4d6e0d56e52d0caee871dc16608cd235c#egg=express[datasets]
+transformers==4.27.3
+torch==2.0.0
+Pillow==9.4.0

--- a/examples/pipelines/hf_dataset_pipeline/components/add_captions/src/main.py
+++ b/examples/pipelines/hf_dataset_pipeline/components/add_captions/src/main.py
@@ -6,7 +6,8 @@ Technically, it adds a data source to the manifest.
 import logging
 from typing import Optional, Union, Dict
 
-from express.components.hf_datasets_components import HFDatasetsTransformComponent, HFDatasetsDataset, HFDatasetsDatasetDraft
+from express.components.hf_datasets_components import HFDatasetsTransformComponent, \
+    HFDatasetsDataset, HFDatasetsDatasetDraft
 from express.logger import configure_logging
 
 configure_logging()
@@ -21,6 +22,7 @@ model = BlipForConditionalGeneration.from_pretrained(repo_id)
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 model.to(device)
+
 
 def add_captions(examples):
     # get batch of images
@@ -42,8 +44,8 @@ class AddCaptions(HFDatasetsTransformComponent):
     """Class that inherits from Hugging Face data transform"""
 
     @classmethod
-    def transform(cls, data: HFDatasetsDataset, args: Optional[
-        Dict[str, Union[str, int, float, bool]]] = None) -> HFDatasetsDatasetDraft:
+    def transform(cls, data: HFDatasetsDataset,
+                  args: Dict[str, Union[str, int, float, bool]] = None) -> HFDatasetsDatasetDraft:
         """
         An example function showcasing the data transform component using Express functionalities
         
@@ -55,15 +57,15 @@ class AddCaptions(HFDatasetsTransformComponent):
         Returns:
             HFDatasetsDatasetDraft: a dataset draft that creates a plan for an output datasets/manifest
         """
-        
+
         # 1) Get one particular data source from the manifest
         logger.info("Loading image dataset...")
         image_dataset = data.load(data_source="images")
-        
+
         # 2) Create new data source
         logger.info("Adding alternative captions...")
         alternative_caption_dataset = image_dataset.map(add_captions, batched=True, batch_size=2,
-                                                          remove_columns=["image", "width", "height"])
+                                                        remove_columns=["image", "width", "height"])
 
         # 3) Create dataset draft which adds a new data source
         logger.info("Creating draft...")

--- a/examples/pipelines/hf_dataset_pipeline/components/add_captions/src/main.py
+++ b/examples/pipelines/hf_dataset_pipeline/components/add_captions/src/main.py
@@ -12,37 +12,37 @@ from express.logger import configure_logging
 configure_logging()
 logger = logging.getLogger(__name__)
 
-from transformers import BlipProcessor, BlipForConditionalGeneration
-import torch
+# from transformers import BlipProcessor, BlipForConditionalGeneration
+# import torch
 
-repo_id = "Salesforce/blip-image-captioning-base"
-processor = BlipProcessor.from_pretrained(repo_id)
-model = BlipForConditionalGeneration.from_pretrained(repo_id)
+# repo_id = "Salesforce/blip-image-captioning-base"
+# processor = BlipProcessor.from_pretrained(repo_id)
+# model = BlipForConditionalGeneration.from_pretrained(repo_id)
+#
+# device = "cuda" if torch.cuda.is_available() else "cpu"
+# model.to(device)
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
-model.to(device)
-
-def add_captions(examples):
-    # get batch of images
-    images = examples["image"]
-
-    # prepare images for the model
-    encoding = processor(images, return_tensors="pt").to(device)
-
-    # generate captions
-    generated_ids = model.generate(**encoding, max_new_tokens=50)
-    generated_captions = processor.batch_decode(generated_ids, skip_special_tokens=True)
-
-    examples["new_caption"] = generated_captions
-
-    return examples
+# def add_captions(examples):
+#     # get batch of images
+#     images = examples["image"]
+#
+#     # prepare images for the model
+#     encoding = processor(images, return_tensors="pt").to(device)
+#
+#     # generate captions
+#     generated_ids = model.generate(**encoding, max_new_tokens=50)
+#     generated_captions = processor.batch_decode(generated_ids, skip_special_tokens=True)
+#
+#     examples["new_caption"] = generated_captions
+#
+#     return examples
 
 
 class AddCaptions(HFDatasetsTransformComponent):
     """Class that inherits from Hugging Face data transform"""
 
     @classmethod
-    def transform(cls, data: HFDatasetsDataset, extra_args: Optional[
+    def transform(cls, data: HFDatasetsDataset, args: Optional[
         Dict[str, Union[str, int, float, bool]]] = None) -> HFDatasetsDatasetDraft:
         """
         An example function showcasing the data transform component using Express functionalities
@@ -61,13 +61,13 @@ class AddCaptions(HFDatasetsTransformComponent):
         image_dataset = data.load(data_source="images")
         
         # 2) Create new data source
-        logger.info("Adding alternative captions...")
-        alternative_caption_dataset = image_dataset.map(add_captions, batched=True, batch_size=2,
-                                                          remove_columns=["image", "width", "height"])
+        # logger.info("Adding alternative captions...")
+        # alternative_caption_dataset = image_dataset.map(add_captions, batched=True, batch_size=2,
+        #                                                   remove_columns=["image", "width", "height"])
         
         # 3) Create dataset draft which adds a new data source
         logger.info("Creating draft...")
-        data_sources = {"alternative_captions": alternative_caption_dataset}
+        data_sources = {"alternative_captions": image_dataset}
         dataset_draft = HFDatasetsDatasetDraft(data_sources=data_sources, extending_dataset=data)
 
         return dataset_draft

--- a/examples/pipelines/hf_dataset_pipeline/components/add_captions/src/main.py
+++ b/examples/pipelines/hf_dataset_pipeline/components/add_captions/src/main.py
@@ -50,7 +50,7 @@ class AddCaptions(HFDatasetsTransformComponent):
         Args:
             data (HFDatasetsDataset[TIndex, TData]): express dataset providing access to data of a
              given type
-            extra_args (Optional[Dict[str, Union[str, int, float, bool]]): optional args to pass to
+            args ([Dict[str, Union[str, int, float, bool]]): optional args to pass to
              the function (e.g. seed data source)
         Returns:
             HFDatasetsDatasetDraft: a dataset draft that creates a plan for an output datasets/manifest

--- a/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/Dockerfile
+++ b/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.8-slim
 
+# Set the working directory to the source folder
+WORKDIR /src
+
 ## System dependencies
 RUN apt-get update && \
     apt-get upgrade -y && \
@@ -22,8 +25,5 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Copy over src-files of the component
 COPY src /src
-
-# Set the working directory to the source folder
-WORKDIR /src
 
 ENTRYPOINT ["python", "main.py"]

--- a/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/README.md
+++ b/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/README.md
@@ -1,8 +1,10 @@
 This component can be run as follows:
 
 ```
-python3 main.py --args '{"dataset_name": "lambdalabs/pokemon-blip-captions"}' \
- --output-manifest <local_path> 
+python3 main.py 
+--args '{"dataset_name": "lambdalabs/pokemon-blip-captions", "run_id":"test",
+"component_name":"test_component","artifact_bucket":"artifact_name"}' \
+--output-manifest <local_path> 
 ```
 
 To build the Docker image, simply run:

--- a/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/README.md
+++ b/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/README.md
@@ -1,10 +1,8 @@
 This component can be run as follows:
 
 ```
-python3 main.py --extra-args '{"dataset_name": "lambdalabs/pokemon-blip-captions"}' \
- --output-manifest <local_path> \
-  --metadata-args '{"run_id":"test","component_name":"test_component", \
-  "artifact_bucket":"artifact_name"}'
+python3 main.py --args '{"dataset_name": "lambdalabs/pokemon-blip-captions"}' \
+ --output-manifest <local_path> 
 ```
 
 To build the Docker image, simply run:

--- a/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/component.yaml
+++ b/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/component.yaml
@@ -1,24 +1,19 @@
 name: load_from_hub
 description: A basic component that takes a dataset name from the 🤗 hub as input and uploads it to a GCS bucket.
-inputs: 
-    - name: extra_args
-      description: Additional arguments passed to the component, as a json dict string
-      type: String
-    
-    - name: metadata_args
-      description: Metadata arguments, passed as a json dict string
-      type: String
-    
+inputs:
+  - name: args
+    description: Component arguments passed as a json dict string
+    type: String
+
 outputs:
-    - name: output_manifest
-      description: Path to the output manifest
+  - name: output_manifest
+    description: Path to the output manifest
 
 implementation:
-    container:
-        image: ghcr.io/ml6team/load_from_hub:latest
-        command: [
-            python3, main.py,
-            --extra-args,          {inputValue: extra_args},
-            --metadata-args,       {inputValue: metadata_args},
-            --output-manifest,     {outputPath: output_manifest},
-        ]
+  container:
+    image: ghcr.io/ml6team/load_from_hub:latest
+    command: [
+      python3, main.py,
+      --args,                { inputValue: args },
+      --output-manifest,     { outputPath: output_manifest },
+    ]

--- a/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/requirements.txt
+++ b/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/requirements.txt
@@ -1,3 +1,2 @@
-datasets
-git+https://github.com/ml6team/express.git@main
-Pillow
+git+https://github.com/ml6team/express.git@27957bb4d6e0d56e52d0caee871dc16608cd235c#egg=express[datasets]
+Pillow==9.4.0

--- a/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/src/main.py
+++ b/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/src/main.py
@@ -33,7 +33,7 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
         """
         An example function showcasing the data loader component using Express functionalities
         Args:
-            args (Optional[Dict[str, Union[str, int, float, bool]]): optional args to pass to
+            args ([Dict[str, Union[str, int, float, bool]]): optional args to pass to
              the function (e.g. seed data source)
         Returns:
             HFDatasetsDatasetDraft: a dataset draft that creates a plan for an output datasets/manifest

--- a/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/src/main.py
+++ b/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/src/main.py
@@ -28,7 +28,7 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
     """Class that inherits from Hugging Face data loading """
 
     @classmethod
-    def load(cls, extra_args: Optional[
+    def load(cls, args: Optional[
         Dict[str, Union[str, int, float, bool]]] = None) -> HFDatasetsDatasetDraft:
         """
         An example function showcasing the data loader component using Express functionalities
@@ -40,7 +40,7 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
         """
         # 1) Create data source
         logger.info("Loading caption dataset from the hub...")
-        dataset = load_dataset(extra_args["dataset_name"], split="train")
+        dataset = load_dataset(args["dataset_name"], split="train")
 
         # 2) Create an example index
         logger.info("Creating index...")
@@ -51,7 +51,7 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
         logger.info("Creating draft...")
         index_dataset = Dataset.from_dict({"index": index_list})
         image_dataset = dataset.remove_columns(["text"]).add_column(name="index", column=index_list)
-        image_dataset = image_dataset.map(create_metadata, batched=True)
+        #image_dataset = image_dataset.map(create_metadata, batched=True)
         text_dataset = dataset.remove_columns(["image"]).add_column(name="index", column=index_list)
         
         data_sources = {"images": image_dataset,

--- a/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/src/main.py
+++ b/examples/pipelines/hf_dataset_pipeline/components/load_from_hub/src/main.py
@@ -33,7 +33,7 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
         """
         An example function showcasing the data loader component using Express functionalities
         Args:
-            extra_args (Optional[Dict[str, Union[str, int, float, bool]]): optional args to pass to
+            args (Optional[Dict[str, Union[str, int, float, bool]]): optional args to pass to
              the function (e.g. seed data source)
         Returns:
             HFDatasetsDatasetDraft: a dataset draft that creates a plan for an output datasets/manifest
@@ -51,7 +51,7 @@ class SeedDatasetLoader(HFDatasetsLoaderComponent):
         logger.info("Creating draft...")
         index_dataset = Dataset.from_dict({"index": index_list})
         image_dataset = dataset.remove_columns(["text"]).add_column(name="index", column=index_list)
-        #image_dataset = image_dataset.map(create_metadata, batched=True)
+        image_dataset = image_dataset.map(create_metadata, batched=True)
         text_dataset = dataset.remove_columns(["image"]).add_column(name="index", column=index_list)
         
         data_sources = {"images": image_dataset,

--- a/examples/pipelines/hf_dataset_pipeline/config/pipeline_config.py
+++ b/examples/pipelines/hf_dataset_pipeline/config/pipeline_config.py
@@ -3,6 +3,7 @@ import os
 
 from dataclasses import dataclass
 
+
 @dataclass
 class GeneralConfig:
     """
@@ -32,7 +33,7 @@ class KubeflowConfig(GeneralConfig):
 
 
 @dataclass
-class LoadFromHubConfig(GeneralConfig):
+class LoadFromHubConfig:
     """
     Config for the data loading component.
     Params:

--- a/examples/pipelines/hf_dataset_pipeline/hf_dataset_pipeline.py
+++ b/examples/pipelines/hf_dataset_pipeline/hf_dataset_pipeline.py
@@ -30,16 +30,23 @@ add_captions_args = create_component_args(component=add_captions_component,
     name='HF Dataset pipeline',
     description='Tiny pipeline that includes 2 components to load and process a HF dataset'
 )
-def hf_dataset_pipeline(load_from_hub_args: str = load_from_hub_args,
-                        add_captions_args: str = add_captions_args):
+def hf_dataset_pipeline(load_from_hub_comp_args: str = load_from_hub_args,
+                        add_captions_comp_args: str = add_captions_args):
+    """
+    An example pipeline that demonstrates the usage of Express to run a pipeline using the HF
+     datasets framework
+    Args:
+        load_from_hub_comp_args (str): load component arguments
+        add_captions_comp_args (str): caption component arguments
+    """
     # Component 1
     load_from_hub_task = load_from_hub_component \
-        (args=load_from_hub_args) \
+        (args=load_from_hub_comp_args) \
         .set_display_name('Load from hub component')
 
     # Component 2
     add_captions_task = add_captions_component \
-        (args=add_captions_args,
+        (args=add_captions_comp_args,
          input_manifest=load_from_hub_task.outputs[
              "output_manifest"],
          ).set_display_name('Add captions component') \

--- a/examples/pipelines/hf_dataset_pipeline/hf_dataset_pipeline.py
+++ b/examples/pipelines/hf_dataset_pipeline/hf_dataset_pipeline.py
@@ -9,44 +9,44 @@ from kubernetes import client as k8s_client
 
 from config.pipeline_config import KubeflowConfig, LoadFromHubConfig
 
-from express.pipeline_utils import create_extra_args, create_metadata_args, compile_and_upload_pipeline
+from express.pipeline_utils import create_component_args, compile_and_upload_pipeline
 
 # Load Components
 artifact_bucket = KubeflowConfig.ARTIFACT_BUCKET
 
 # Component 1: load from hub
 load_from_hub_component = comp.load_component('components/load_from_hub/component.yaml')
-load_from_hub_extra_args = create_extra_args(dataset_name=LoadFromHubConfig.DATASET_NAME)
-load_from_hub_metadata_args = create_metadata_args(load_from_hub_component, artifact_bucket)
+load_from_hub_args = create_component_args(component=load_from_hub_component,
+                                           artifact_bucket=artifact_bucket,
+                                           dataset_name=LoadFromHubConfig.DATASET_NAME)
 
 # Component 2: add captions
 add_captions_component = comp.load_component('components/add_captions/component.yaml')
-add_captions_extra_args = create_extra_args()
-add_captions_metadata_args = create_metadata_args(add_captions_component, artifact_bucket)
+add_captions_args = create_component_args(component=add_captions_component,
+                                          artifact_bucket=artifact_bucket)
+
 
 # Pipeline
 @dsl.pipeline(
     name='HF Dataset pipeline',
     description='Tiny pipeline that includes 2 components to load and process a HF dataset'
 )
-def hf_dataset_pipeline(load_from_hub_extra_args: str = load_from_hub_extra_args,
-                        load_from_hub_metadata_args: str = load_from_hub_metadata_args,
-                        add_captions_extra_args: str = add_captions_extra_args,
-                        add_captions_metadata_args: str = add_captions_metadata_args,
-                        ):
+def hf_dataset_pipeline(load_from_hub_args: str = load_from_hub_args,
+                        add_captions_args: str = add_captions_args):
     # Component 1
-    load_from_hub_task = load_from_hub_component(extra_args=load_from_hub_extra_args,
-                                          metadata_args=load_from_hub_metadata_args,
-    ).set_display_name('Load from hub component')
+    load_from_hub_task = load_from_hub_component \
+        (args=load_from_hub_args) \
+        .set_display_name('Load from hub component')
 
     # Component 2
-    add_captions_task = add_captions_component(extra_args=add_captions_extra_args,
-                                        metadata=add_captions_metadata_args,
-                                        input_manifest=load_from_hub_task.outputs["output_manifest"],
-    ).set_display_name('Add captions component') \
-    .set_gpu_limit(1) \
-    .add_node_selector_constraint('node_pool', 'model-inference-pool') \
-    .add_toleration(
+    add_captions_task = add_captions_component \
+        (args=add_captions_args,
+         input_manifest=load_from_hub_task.outputs[
+             "output_manifest"],
+         ).set_display_name('Add captions component') \
+        .set_gpu_limit(1) \
+        .add_node_selector_constraint('node_pool', 'model-inference-pool') \
+        .add_toleration(
         k8s_client.V1Toleration(effect='NoSchedule', key='reserved-pool', operator='Equal',
                                 value='true'))
 

--- a/examples/pipelines/hf_dataset_pipeline/hf_dataset_pipeline.py
+++ b/examples/pipelines/hf_dataset_pipeline/hf_dataset_pipeline.py
@@ -8,7 +8,6 @@ from kfp import dsl
 from kubernetes import client as k8s_client
 
 from config.pipeline_config import KubeflowConfig, LoadFromHubConfig
-
 from express.pipeline_utils import create_component_args, compile_and_upload_pipeline
 
 # Load Components

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -248,19 +248,6 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
         """
 
     @classmethod
-    def _create_metadata(cls, args: dict) -> Metadata:
-        """
-        Create the manifest metadata
-        Args:
-            args (dict): a dictionary containing metadata information
-        Returns:
-            Metadata: the initial metadata
-        """
-
-        initial_metadata = Metadata()
-        return cls._update_metadata(initial_metadata, args)
-
-    @classmethod
     def _update_metadata(
             cls,
             metadata: Metadata,
@@ -270,8 +257,8 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
         Update the manifest metadata
         Args:
             metadata (metadata): the previous component metadata
-            metadata_args (dict): a dictionary containing metadata information related to the
-            current component
+            args ([Dict[str, Union[str, int, float, bool]]): Component arguments passed as a
+             json dict string
         Returns:
             Metadata: the initial metadata
         """
@@ -362,7 +349,7 @@ class ExpressTransformComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
             "--args",
             type=str,
             required=True,
-            help="Extra arguments for the component, passed as a json dict string",
+            help="Component arguments passed as a json dict string",
         )
         parser.add_argument(
             "--output-manifest",
@@ -390,8 +377,8 @@ class ExpressTransformComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
         Args:
             data (ExpressDataset[TIndex, TData]): express dataset providing access to data of a
              given type
-            args (Optional[Dict[str, Union[str, int, float, bool]]]): an optional dictionary
-             of additional arguments passed in by the pipeline run
+            args (Optional[Dict[str, Union[str, int, float, bool]]]): Component arguments passed as
+             a json dict string
 
         Returns:
             ExpressDatasetDraft[TIndex, TData]: draft of output dataset, to be uploaded after this
@@ -438,7 +425,7 @@ class ExpressLoaderComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
             "--args",
             type=str,
             required=True,
-            help="Extra arguments, passed as a json dict string",
+            help="Component arguments passed as a json dict string",
         )
         parser.add_argument(
             "--output-manifest",
@@ -457,9 +444,8 @@ class ExpressLoaderComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
         Loads data from an arbitrary source to create a draft for a new dataset.
 
         Args:
-            #TODO update
-            args (Optional[Dict[str, Union[str, int, float, bool]]): an optional dictionary
-             of additional arguments passed in by the pipeline run
+            args ([Dict[str, Union[str, int, float, bool]]): Component arguments passed as a
+             json dict string
 
         Returns:
             ExpressDatasetDraft[TIndex, TData]: draft of output dataset, to be uploaded after this

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -75,7 +75,7 @@ class ExpressDataset(ABC, Generic[IndexT, DataT]):
     @staticmethod
     @abstractmethod
     def _load_data_source(
-            data_source: DataSource, index_filter: Optional[IndexT]
+        data_source: DataSource, index_filter: Optional[IndexT]
     ) -> DataT:
         """
         Load data from a (possibly remote) path.
@@ -109,10 +109,10 @@ class ExpressDatasetDraft(ABC, Generic[IndexT, DataT]):
     """
 
     def __init__(
-            self,
-            index: Optional[Union[DataSource, IndexT]] = None,
-            data_sources: Dict[str, Union[DataSource, DataT]] = None,
-            extending_dataset: Optional[ExpressDataset[IndexT, DataT]] = None,
+        self,
+        index: Optional[Union[DataSource, IndexT]] = None,
+        data_sources: Dict[str, Union[DataSource, DataT]] = None,
+        extending_dataset: Optional[ExpressDataset[IndexT, DataT]] = None,
     ):
         self.index = index
         self.data_sources = data_sources or {}
@@ -135,7 +135,7 @@ class ExpressDatasetDraft(ABC, Generic[IndexT, DataT]):
 
     @classmethod
     def extend(
-            cls, dataset: ExpressDataset[IndexT, DataT]
+        cls, dataset: ExpressDataset[IndexT, DataT]
     ) -> "ExpressDatasetDraft[IndexT, DataT]":
         """
         Creates a new Express Dataset draft extending the given dataset, which will take over both
@@ -154,7 +154,7 @@ class ExpressDatasetDraft(ABC, Generic[IndexT, DataT]):
         return self
 
     def with_data_source(
-            self, name: str, data: Union[DataT, DataSource], replace_ok=False
+        self, name: str, data: Union[DataT, DataSource], replace_ok=False
     ) -> "ExpressDatasetDraft[IndexT, DataT]":
         """
         Adds a new data source or replaces a preexisting data source with the same name.
@@ -209,7 +209,7 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
     @classmethod
     @abstractmethod
     def _load_dataset(
-            cls, input_manifest: DataManifest
+        cls, input_manifest: DataManifest
     ) -> ExpressDataset[IndexT, DataT]:
         """
         Parses a manifest to an ExpressDataset of a specific type, for downstream use by transform
@@ -233,7 +233,7 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
     @classmethod
     @abstractmethod
     def _upload_data_source(
-            cls, name: str, data: DataT, remote_path: str
+        cls, name: str, data: DataT, remote_path: str
     ) -> DataSource:
         """
         Uploads data of a certain type as parquet and creates a new DataSource.
@@ -249,9 +249,9 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
 
     @classmethod
     def _update_metadata(
-            cls,
-            metadata: Metadata,
-            args: Optional[Dict[str, Union[str, int, float, bool]]],
+        cls,
+        metadata: Metadata,
+        args: Optional[Dict[str, Union[str, int, float, bool]]],
     ) -> Metadata:
         """
         Update the manifest metadata
@@ -263,7 +263,9 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
             Metadata: the initial metadata
         """
         metadata_dict = metadata.to_dict()
-        metadata_args = {key: value for key, value in args.items() if key in metadata_dict}
+        metadata_args = {
+            key: value for key, value in args.items() if key in metadata_dict
+        }
         for metadata_key, metadata_value in metadata_args.items():
             metadata_dict[metadata_key] = metadata_value
         metadata_dict["git branch"] = os.environ.get("GIT_BRANCH")
@@ -274,10 +276,10 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
 
     @classmethod
     def _create_output_dataset(
-            cls,
-            draft: ExpressDatasetDraft[IndexT, DataT],
-            metadata: Metadata,
-            save_path: str,
+        cls,
+        draft: ExpressDatasetDraft[IndexT, DataT],
+        metadata: Metadata,
+        save_path: str,
     ) -> DataManifest:
         """
         Processes a dataset draft of a specific type, uploading all local data to storage and
@@ -324,8 +326,9 @@ class ExpressTransformComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
         input_dataset = cls._load_dataset(input_manifest)
 
         output_dataset_draft = cls.transform(data=input_dataset, args=args_dict)
-        metadata = cls._update_metadata(metadata=input_manifest.metadata,
-                                        args=args_dict)
+        metadata = cls._update_metadata(
+            metadata=input_manifest.metadata, args=args_dict
+        )
         output_manifest = cls._create_output_dataset(
             draft=output_dataset_draft,
             metadata=metadata,
@@ -362,9 +365,9 @@ class ExpressTransformComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
     @classmethod
     @abstractmethod
     def transform(
-            cls,
-            data: ExpressDataset[IndexT, DataT],
-            args: Optional[Dict[str, Union[str, int, float, bool]]] = None,
+        cls,
+        data: ExpressDataset[IndexT, DataT],
+        args: Optional[Dict[str, Union[str, int, float, bool]]] = None,
     ) -> ExpressDatasetDraft[IndexT, DataT]:
         """
         Applies transformations to the input dataset and creates a draft for a new dataset.
@@ -405,8 +408,7 @@ class ExpressLoaderComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
         parsed_args = cls._parse_args()
         args_dict = json.loads(parsed_args.args)
         output_dataset_draft = cls.load(args=args_dict)
-        metadata = cls._update_metadata(metadata=Metadata(),
-                                        args=args_dict)
+        metadata = cls._update_metadata(metadata=Metadata(), args=args_dict)
         # Create metadata
         output_manifest = cls._create_output_dataset(
             draft=output_dataset_draft,
@@ -438,7 +440,7 @@ class ExpressLoaderComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
     @classmethod
     @abstractmethod
     def load(
-            cls, args: Dict[str, Union[str, int, float, bool]]
+        cls, args: Dict[str, Union[str, int, float, bool]]
     ) -> ExpressDatasetDraft[IndexT, DataT]:
         """
         Loads data from an arbitrary source to create a draft for a new dataset.

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -251,7 +251,7 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
     def _update_metadata(
         cls,
         metadata: Metadata,
-        args: Optional[Dict[str, Union[str, int, float, bool]]],
+        args: Dict[str, Union[str, int, float, bool]],
     ) -> Metadata:
         """
         Update the manifest metadata
@@ -367,7 +367,7 @@ class ExpressTransformComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
     def transform(
         cls,
         data: ExpressDataset[IndexT, DataT],
-        args: Optional[Dict[str, Union[str, int, float, bool]]] = None,
+        args: Dict[str, Union[str, int, float, bool]] = None,
     ) -> ExpressDatasetDraft[IndexT, DataT]:
         """
         Applies transformations to the input dataset and creates a draft for a new dataset.

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -146,7 +146,7 @@ class HFDatasetsTransformComponent(
     def transform(
         cls,
         data: HFDatasetsDataset,
-        extra_args: Optional[Dict[str, Union[str, int, float, bool]]] = None,
+        args: Optional[Dict[str, Union[str, int, float, bool]]] = None,
     ) -> HFDatasetsDatasetDraft:
         """Transform dataset"""
 
@@ -160,6 +160,6 @@ class HFDatasetsLoaderComponent(
     @classmethod
     @abstractmethod
     def load(
-        cls, extra_args: Optional[Dict[str, Union[str, int, float, bool]]] = None
+        cls, args: Optional[Dict[str, Union[str, int, float, bool]]] = None
     ) -> HFDatasetsDatasetDraft:
         """Load initial dataset"""

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -4,7 +4,7 @@ import os
 import importlib
 import tempfile
 from abc import ABC, abstractmethod
-from typing import List, Optional, Dict, Union
+from typing import List, Dict, Union
 
 from express.storage_interface import StorageHandlerModule
 from express.manifest import DataManifest, DataSource, DataType
@@ -146,7 +146,7 @@ class HFDatasetsTransformComponent(
     def transform(
         cls,
         data: HFDatasetsDataset,
-        args: Optional[Dict[str, Union[str, int, float, bool]]] = None,
+        args: Dict[str, Union[str, int, float, bool]] = None,
     ) -> HFDatasetsDatasetDraft:
         """Transform dataset"""
 
@@ -160,6 +160,6 @@ class HFDatasetsLoaderComponent(
     @classmethod
     @abstractmethod
     def load(
-        cls, args: Optional[Dict[str, Union[str, int, float, bool]]] = None
+        cls, args: Dict[str, Union[str, int, float, bool]] = None
     ) -> HFDatasetsDatasetDraft:
         """Load initial dataset"""

--- a/express/components/pandas_components.py
+++ b/express/components/pandas_components.py
@@ -4,7 +4,7 @@ import os
 import importlib
 import tempfile
 from abc import ABC, abstractmethod
-from typing import List, Optional, Dict, Union
+from typing import List, Dict, Union
 
 from express.components.common import (
     ExpressDatasetHandler,
@@ -123,7 +123,7 @@ class PandasTransformComponent(
     def transform(
         cls,
         data: PandasDataset,
-        extra_args: Optional[Dict[str, Union[str, int, float, bool]]] = None,
+        args: Dict[str, Union[str, int, float, bool]] = None,
     ) -> PandasDatasetDraft:
         """Transform dataset"""
 
@@ -136,6 +136,6 @@ class PandasLoaderComponent(
     @classmethod
     @abstractmethod
     def load(
-        cls, extra_args: Optional[Dict[str, Union[str, int, float, bool]]] = None
+        cls, args: Dict[str, Union[str, int, float, bool]] = None
     ) -> PandasDatasetDraft:
         """Load initial dataset"""

--- a/express/pipeline_utils.py
+++ b/express/pipeline_utils.py
@@ -9,26 +9,26 @@ from express.import_utils import is_kfp_available
 
 if is_kfp_available():
     import kfp
-    import kfp.v2.dsl as dsl
 
 logger = logging.getLogger(__name__)
 
 
-def create_component_args(artifact_bucket: str, **kwargs) -> str:
+def create_component_args(component: kfp.components, artifact_bucket: str, **kwargs) -> str:
     """
     Function that creates the component arguments as a json string
     Args:
+        component (kfp.component): the kubeflow component to create the arguments for
         artifact_bucket (str): the name of the bucket where the artifacts will be stored
         **kwargs: additional components arguments
     Returns:
         str: json string of component arguments
     """
     metadata_args = {
-        "run_id": dsl.PIPELINE_JOB_ID_PLACEHOLDER,
-        "component_name": dsl.PIPELINE_TASK_ID_PLACEHOLDER,
+        "run_id": "{{workflow.name}}",
+        "component_name": f"{component.__name__}",
         "artifact_bucket": artifact_bucket,
     }
-    extra_args = {k.lower(): v for k, v in kwargs.items()}
+    extra_args = {key.lower(): value for key, value in kwargs.items()}
 
     return json.dumps(extra_args | metadata_args)
 

--- a/express/pipeline_utils.py
+++ b/express/pipeline_utils.py
@@ -9,32 +9,32 @@ from express.import_utils import is_kfp_available
 
 if is_kfp_available():
     import kfp
+    import kfp.v2.dsl as dsl
 
 logger = logging.getLogger(__name__)
 
 
-def create_extra_args(**kwargs):
-    # create dict
-    config_dict = {k.lower(): v for k, v in kwargs.items()}
-    # turn into string representation
-    extra_args = json.dumps(config_dict)
-    return extra_args
-
-
-def create_metadata_args(component, artifact_bucket):
-    run_id = "{{workflow.name}}"
-
+def create_component_args(artifact_bucket: str, **kwargs) -> str:
+    """
+    Function that created the component
+    Args:
+        artifact_bucket (str): the name of the bucket where the artifacts will be stored
+        **kwargs: additional components arguments
+    Returns:
+        str: json string of component arguments
+    """
     metadata_args = {
-        "run_id": run_id,
-        "component_name": component.__name__,
+        "run_id": dsl.PIPELINE_JOB_ID_PLACEHOLDER,
+        "component_name": dsl.PIPELINE_TASK_ID_PLACEHOLDER,
         "artifact_bucket": artifact_bucket,
     }
-    metadata_args = json.dumps(metadata_args)
-    return metadata_args
+    extra_args = {k.lower(): v for k, v in kwargs.items()}
+
+    return json.dumps(extra_args | metadata_args)
 
 
 def compile_and_upload_pipeline(
-    pipeline: Callable[[], None], host: str, env: str
+        pipeline: Callable[[], None], host: str, env: str
 ) -> None:
     """Upload pipeline to kubeflow.
     Args:

--- a/express/pipeline_utils.py
+++ b/express/pipeline_utils.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def create_component_args(artifact_bucket: str, **kwargs) -> str:
     """
-    Function that created the component
+    Function that creates the component arguments as a json string
     Args:
         artifact_bucket (str): the name of the bucket where the artifacts will be stored
         **kwargs: additional components arguments

--- a/express/pipeline_utils.py
+++ b/express/pipeline_utils.py
@@ -13,7 +13,9 @@ if is_kfp_available():
 logger = logging.getLogger(__name__)
 
 
-def create_component_args(component: kfp.components, artifact_bucket: str, **kwargs) -> str:
+def create_component_args(
+    component: kfp.components, artifact_bucket: str, **kwargs
+) -> str:
     """
     Function that creates the component arguments as a json string
     Args:
@@ -34,7 +36,7 @@ def create_component_args(component: kfp.components, artifact_bucket: str, **kwa
 
 
 def compile_and_upload_pipeline(
-        pipeline: Callable[[], None], host: str, env: str
+    pipeline: Callable[[], None], host: str, env: str
 ) -> None:
     """Upload pipeline to kubeflow.
     Args:

--- a/express/pipeline_utils.py
+++ b/express/pipeline_utils.py
@@ -27,7 +27,7 @@ def create_component_args(
     """
     metadata_args = {
         "run_id": "{{workflow.name}}",
-        "component_name": f"{component.__name__}",
+        "component_name": component.__name__,
         "artifact_bucket": artifact_bucket,
     }
     extra_args = {key.lower(): value for key, value in kwargs.items()}


### PR DESCRIPTION
PR that simplifies the way the way that components arguments are built and passed to the components. 

The previous implementation relied on the user providing both the component arguments and the metadata arguments. The latter is something that the end-user does not need to take care off. It also makes the arguments passed to each component more straightforward (args, manifest input, mainfest output).

**Note:** the PR branches off this [PR](https://github.com/ml6team/express/pull/21)