### PR TITLE
[WIP] Add general taxonomy

### DIFF
--- a/examples/pipelines/finetune_stable_diffusion/components/embedding_component/requirements.txt
+++ b/examples/pipelines/finetune_stable_diffusion/components/embedding_component/requirements.txt
@@ -1,4 +1,4 @@
 torch==2.0.0
 transformers==4.27.3
-git+https://github.com/ml6team/express.git@2cf67be1215118e9f98b8c7b34966ffcdee03cf3
+git+https://github.com/ml6team/express.git@e74a097541bf5f5607c7ba1a532c246ca9ebeb9d
 Pillow==9.4.0

--- a/examples/pipelines/finetune_stable_diffusion/components/embedding_component/requirements.txt
+++ b/examples/pipelines/finetune_stable_diffusion/components/embedding_component/requirements.txt
@@ -1,4 +1,4 @@
 torch==2.0.0
 transformers==4.27.3
-git+https://github.com/ml6team/express.git@0f43bbd88826ffd1b620100275700f9cbe7c0b6e
+git+https://github.com/ml6team/express.git@2cf67be1215118e9f98b8c7b34966ffcdee03cf3
 Pillow==9.4.0

--- a/examples/pipelines/finetune_stable_diffusion/components/embedding_component/src/main.py
+++ b/examples/pipelines/finetune_stable_diffusion/components/embedding_component/src/main.py
@@ -4,7 +4,7 @@ This component adds a data source to the manifest by embedding the images.
 import logging
 from typing import Optional, Union, Dict
 
-
+import express
 from express.components.hf_datasets_components import (
     HFDatasetsTransformComponent,
     HFDatasetsDataset,
@@ -51,6 +51,8 @@ class EmbeddingComponent(HFDatasetsTransformComponent):
     """
     Component that embeds the images using a CLIP model from Hugging Face.
     """
+    data_sources_in = [("images", express.Image)]
+    data_sources_out = [("embeddings", express.Text)]
 
     @classmethod
     def transform(

--- a/examples/pipelines/finetune_stable_diffusion/components/embedding_component/src/main.py
+++ b/examples/pipelines/finetune_stable_diffusion/components/embedding_component/src/main.py
@@ -52,7 +52,7 @@ class EmbeddingComponent(HFDatasetsTransformComponent):
     Component that embeds the images using a CLIP model from Hugging Face.
     """
     data_sources_in = [("images", express.Image)]
-    data_sources_out = [("embeddings", express.Text)]
+    data_sources_out = [("embeddings", express.Vector)]
 
     @classmethod
     def transform(

--- a/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/requirements.txt
+++ b/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/requirements.txt
@@ -1,2 +1,2 @@
 datasets==2.10.1
-git+https://github.com/ml6team/express.git@e74a097541bf5f5607c7ba1a532c246ca9ebeb9d
+git+https://github.com/ml6team/express.git@8771d9b2d9421eae22b0e67968129efb4295b4d8

--- a/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/requirements.txt
+++ b/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/requirements.txt
@@ -1,2 +1,2 @@
 datasets==2.10.1
-git+https://github.com/ml6team/express.git@2d630255f82c6a9d7d15e7be23ff3d9b9ba16723
+git+https://github.com/ml6team/express.git@2cf67be1215118e9f98b8c7b34966ffcdee03cf3

--- a/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/requirements.txt
+++ b/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/requirements.txt
@@ -1,2 +1,2 @@
 datasets==2.10.1
-git+https://github.com/ml6team/express.git@2cf67be1215118e9f98b8c7b34966ffcdee03cf3
+git+https://github.com/ml6team/express.git@e74a097541bf5f5607c7ba1a532c246ca9ebeb9d

--- a/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/src/main.py
+++ b/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/src/main.py
@@ -33,7 +33,7 @@ class ImageFilterComponent(HFDatasetsTransformComponent):
     Goal is to leverage streaming."""
 
     data_sources_in = [("images", express.Image)]
-    data_sources_out = None
+    data_sources_out = [("images", express.Image)]
 
     @classmethod
     def transform(

--- a/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/src/main.py
+++ b/examples/pipelines/finetune_stable_diffusion/components/image_filter_component/src/main.py
@@ -8,6 +8,7 @@ from typing import Optional, Union, Dict
 
 from datasets import Dataset
 
+import express
 from express.components.hf_datasets_components import (
     HFDatasetsTransformComponent,
     HFDatasetsDataset,
@@ -30,6 +31,9 @@ class ImageFilterComponent(HFDatasetsTransformComponent):
     Class that inherits from Hugging Face data transform.
 
     Goal is to leverage streaming."""
+
+    data_sources_in = [("images", express.Image)]
+    data_sources_out = None
 
     @classmethod
     def transform(

--- a/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/requirements.txt
+++ b/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/requirements.txt
@@ -1,3 +1,3 @@
 datasets==2.10.1
-git+https://github.com/ml6team/express.git@e74a097541bf5f5607c7ba1a532c246ca9ebeb9d
+git+https://github.com/ml6team/express.git@8771d9b2d9421eae22b0e67968129efb4295b4d8
 Pillow==9.4.0

--- a/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/requirements.txt
+++ b/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/requirements.txt
@@ -1,3 +1,3 @@
 datasets==2.10.1
-git+https://github.com/ml6team/express.git@2cf67be1215118e9f98b8c7b34966ffcdee03cf3
+git+https://github.com/ml6team/express.git@e74a097541bf5f5607c7ba1a532c246ca9ebeb9d
 Pillow==9.4.0

--- a/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/requirements.txt
+++ b/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/requirements.txt
@@ -1,3 +1,3 @@
 datasets==2.10.1
-git+https://github.com/ml6team/express.git@main
+git+https://github.com/ml6team/express.git@2cf67be1215118e9f98b8c7b34966ffcdee03cf3
 Pillow==9.4.0

--- a/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/src/main.py
+++ b/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/src/main.py
@@ -7,7 +7,7 @@ from typing import Optional, Union, Dict
 
 from datasets import Dataset, load_dataset
 
-import express
+from express.taxonomy import Image, Text
 from express.components.hf_datasets_components import (
     HFDatasetsLoaderComponent,
     HFDatasetsDatasetDraft,
@@ -34,7 +34,7 @@ class LoadFromHubComponent(HFDatasetsLoaderComponent):
     """Component that loads a dataset from the hub and creates the initial manifest."""
 
     data_sources_in = None
-    data_sources_out = [("images", express.taxonomy.Image), ("captions", express.taxonomy.Text)]
+    data_sources_out = [("images", Image()), ("captions", Text())]
 
     @classmethod
     def load(

--- a/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/src/main.py
+++ b/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/src/main.py
@@ -7,6 +7,7 @@ from typing import Optional, Union, Dict
 
 from datasets import Dataset, load_dataset
 
+import express
 from express.components.hf_datasets_components import (
     HFDatasetsLoaderComponent,
     HFDatasetsDatasetDraft,
@@ -31,6 +32,9 @@ def create_image_metadata(batch):
 
 class LoadFromHubComponent(HFDatasetsLoaderComponent):
     """Component that loads a dataset from the hub and creates the initial manifest."""
+
+    data_sources_in = None
+    data_sources_out = [("images", express.Image), ("captions", express.Text)]
 
     @classmethod
     def load(

--- a/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/src/main.py
+++ b/examples/pipelines/finetune_stable_diffusion/components/load_from_hub_component/src/main.py
@@ -34,7 +34,7 @@ class LoadFromHubComponent(HFDatasetsLoaderComponent):
     """Component that loads a dataset from the hub and creates the initial manifest."""
 
     data_sources_in = None
-    data_sources_out = [("images", express.Image), ("captions", express.Text)]
+    data_sources_out = [("images", express.taxonomy.Image), ("captions", express.taxonomy.Text)]
 
     @classmethod
     def load(

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -3,7 +3,6 @@ This file is the entrypoint of the component. It will parse all arguments
 and give them to the actual core of the component.
 """
 import argparse
-import dataclasses
 import json
 import os
 import importlib
@@ -357,17 +356,16 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
                     f"Output manifest is missing data source {expected_data_source}"
                 )
             data_source = draft.data_sources[expected_data_source]
-            # verify that the required fields are present
+            # verify that the required columns are present
             cls._verify_data_source(data_source, modality)
 
         return True
 
     def _verify_data_source(cls, data_source, modality):
-        modality_fields = [field.name for field in dataclasses.fields(modality)]
-        for field in modality_fields:
-            if field not in data_source.column_names:
+        for column in modality.required_columns():
+            if column not in data_source.column_names:
                 raise ValueError(
-                    f"Data source {data_source} is missing the required column {field} "
+                    f"Data source {data_source} is missing the required column {column} "
                 )
 
 

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -192,6 +192,16 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
      Pandas DataFrame or a Spark RDD.
     """
 
+    @property
+    @abstractmethod
+    def data_sources_in(self):
+        pass
+
+    @property
+    @abstractmethod
+    def data_sources_out(self):
+        pass
+
     @staticmethod
     def _path_for_upload(metadata: Metadata, name: str) -> str:
         """

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -331,6 +331,7 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
         Path(save_path).write_text(manifest.to_json(), encoding="utf-8")
         return manifest
 
+    @classmethod
     def _verify_data_sources_in(cls, data: ExpressDataset):
         if cls.data_sources_in is None:
             return True
@@ -346,6 +347,7 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
 
         return True
 
+    @classmethod
     def _verify_data_sources_out(cls, draft: ExpressDatasetDraft):
         if cls.data_sources_out is None:
             return True
@@ -361,11 +363,12 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
 
         return True
 
+    @classmethod
     def _verify_data_source(cls, data_source, modality):
         for column in modality.required_columns():
             if column not in data_source.column_names:
                 raise ValueError(
-                    f"Data source {data_source} is missing the required column {column} "
+                    f"Data source {modality} is missing the required column {column} "
                 )
 
 
@@ -486,8 +489,9 @@ class ExpressLoaderComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
         if cls.data_sources_in is not None:
             raise ValueError("Loader components should not have input data sources.")
         output_dataset_draft = cls.load(extra_args=json.loads(args.extra_args))
+        print("Output draft:", output_dataset_draft)
         # verify outgoing data sources
-        cls._verify_data_sources_out(output_dataset_draft)
+        cls._verify_data_sources_out(draft=output_dataset_draft)
         # create metadata
         metadata = cls._create_metadata(metadata_args=json.loads(args.metadata_args))
         # create output manifest

--- a/express/components/common.py
+++ b/express/components/common.py
@@ -3,6 +3,7 @@ This file is the entrypoint of the component. It will parse all arguments
 and give them to the actual core of the component.
 """
 import argparse
+import dataclasses
 import json
 import os
 import importlib
@@ -332,32 +333,42 @@ class ExpressDatasetHandler(ABC, Generic[IndexT, DataT]):
         return manifest
 
     def _verify_data_sources_in(cls, data: ExpressDataset):
-        for expected_data_source in cls.data_sources_in:
+        if cls.data_sources_in is None:
+            return True
+        for expected_data_source, modality in cls.data_sources_in:
             # get the data source from the manifest
-            if expected_data_source[0] not in data.manifest.data_sources:
+            if expected_data_source not in data.manifest.data_sources:
                 raise ValueError(
-                    f"Input dataset is missing data source {expected_data_source}"
+                    f"Input manifest is missing data source {expected_data_source}"
                 )
-            data.manifest.data_sources[expected_data_source[0]]
-            # TODO verify that the required fields are present
-            # according to the taxonomy expected_data_source[1]
-            continue
+            data_source = data.manifest.data_sources[expected_data_source]
+            # verify that the required fields are present
+            cls._verify_data_source(data_source, modality)
 
         return True
 
-    def _verify_data_sources_out(cls, draft):
-        for expected_data_source in cls.data_sources_out:
+    def _verify_data_sources_out(cls, draft: ExpressDatasetDraft):
+        if cls.data_sources_out is None:
+            return True
+        for expected_data_source, modality in cls.data_sources_out:
             # get the data source from the draft
-            if expected_data_source[0] not in draft.data_sources:
+            if expected_data_source not in draft.data_sources:
                 raise ValueError(
-                    f"Output dataset draft is missing data source {expected_data_source}"
+                    f"Output manifest is missing data source {expected_data_source}"
                 )
-            draft.data_sources[expected_data_source[0]]
-            # TODO verify that the required fields are present
-            # according to the taxonomy expected_data_source[1]
-            continue
+            data_source = draft.data_sources[expected_data_source]
+            # verify that the required fields are present
+            cls._verify_data_source(data_source, modality)
 
         return True
+
+    def _verify_data_source(cls, data_source, modality):
+        modality_fields = [field.name for field in dataclasses.fields(modality)]
+        for field in modality_fields:
+            if field not in data_source.column_names:
+                raise ValueError(
+                    f"Data source {data_source} is missing the required column {field} "
+                )
 
 
 class ExpressTransformComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
@@ -379,13 +390,13 @@ class ExpressTransformComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
         input_dataset = cls._load_dataset(
             input_manifest=DataManifest.from_path(args.input_manifest)
         )
-        # verify input data sources
+        # verify incoming data sources
         cls._verify_data_sources_in(input_dataset)
         # transform
         output_dataset_draft = cls.transform(
             data=input_dataset, extra_args=json.loads(args.extra_args)
         )
-        # verify output data sources
+        # verify outgoing data sources
         cls._verify_data_sources_out(output_dataset_draft)
         # create metadata
         metadata = Metadata.from_dict(json.loads(args.metadata))
@@ -477,11 +488,11 @@ class ExpressLoaderComponent(ExpressDatasetHandler, Generic[IndexT, DataT]):
         if cls.data_sources_in is not None:
             raise ValueError("Loader components should not have input data sources.")
         output_dataset_draft = cls.load(extra_args=json.loads(args.extra_args))
-        # verify output data sources
+        # verify outgoing data sources
         cls._verify_data_sources_out(output_dataset_draft)
-        # Create metadata
+        # create metadata
         metadata = cls._create_metadata(metadata_args=json.loads(args.metadata_args))
-        # Create output manifest
+        # create output manifest
         output_manifest = cls._create_output_dataset(
             draft=output_dataset_draft,
             save_path=args.output_manifest,

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -108,10 +108,8 @@ class HFDatasetsDatasetHandler(ExpressDatasetHandler[List[str], datasets.Dataset
 
             return DataSource(
                 location=fully_qualified_blob_path,
-                type=DataType.PARQUET,
-                extensions=["parquet"],
-                n_files=1,
-                n_items=len(data),
+                len=len(data),
+                column_names=data.column_names,
             )
 
     @classmethod

--- a/express/components/hf_datasets_components.py
+++ b/express/components/hf_datasets_components.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from typing import List, Optional, Dict, Union
 
 from express.storage_interface import StorageHandlerModule
-from express.manifest import DataManifest, DataSource, DataType
+from express.manifest import DataManifest, DataSource
 from express.import_utils import is_datasets_available
 from .common import (
     ExpressDatasetHandler,
@@ -57,9 +57,6 @@ class HFDatasetsDataset(ExpressDataset[List[str], datasets.Dataset]):
         **kwargs,
     ) -> datasets.Dataset:
         """Function that loads in a data source"""
-        if data_source.type != DataType.PARQUET:
-            raise TypeError("Only reading from parquet is currently supported.")
-
         with tempfile.TemporaryDirectory() as tmp_dir:
             data_source_location = data_source.location
 

--- a/express/components/pandas_components.py
+++ b/express/components/pandas_components.py
@@ -13,7 +13,7 @@ from express.components.common import (
     ExpressDatasetDraft,
     ExpressLoaderComponent,
 )
-from express.manifest import DataManifest, DataSource, DataType
+from express.manifest import DataManifest, DataSource
 from express.storage_interface import StorageHandlerModule
 from express.import_utils import is_pandas_available
 
@@ -45,9 +45,6 @@ class PandasDataset(ExpressDataset[List[str], Union[pd.DataFrame, pd.Series]]):
     def _load_data_source(
         data_source: DataSource, index_filter: Union[pd.DataFrame, pd.Series, List[str]]
     ) -> pd.DataFrame:
-        if data_source.type != DataType.PARQUET:
-            raise TypeError("Only reading from parquet is currently supported.")
-
         with tempfile.TemporaryDirectory() as tmp_dir:
             data_source_location = data_source.location
 
@@ -86,10 +83,7 @@ class PandasDatasetHandler(ExpressDatasetHandler[List[str], pd.DataFrame]):
             )
             return DataSource(
                 location=fully_qualified_blob_path,
-                type=DataType.PARQUET,
-                extensions=["parquet"],
-                n_files=1,
-                n_items=len(data),
+                len=len(data),
             )
 
     @classmethod

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -34,6 +34,17 @@ class Text:
 
 
 @dataclass
+class Vector:
+    """
+    A single vector
+    Args:
+        size (int): size of the vector
+    """
+
+    size: int
+
+
+@dataclass
 class DataSource:
     """
     Information about the location and contents of a single data source.

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -10,41 +10,6 @@ from dataclasses_json import dataclass_json
 
 
 @dataclass
-class Image:
-    """
-    A single image
-    Args:
-        width (int): width of the image
-        height (int): height of the image
-    """
-
-    width: int
-    height: int
-
-
-@dataclass
-class Text:
-    """
-    A single text
-    Args:
-        len (int): length of the text
-    """
-
-    len: int
-
-
-@dataclass
-class Vector:
-    """
-    A single vector
-    Args:
-        size (int): size of the vector
-    """
-
-    size: int
-
-
-@dataclass
 class DataSource:
     """
     Information about the location and contents of a single data source.

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -55,6 +55,7 @@ class DataSource:
 
     location: str
     len: int
+    column_names: list
 
 
 @dataclass_json

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -68,7 +68,9 @@ class DataManifest:
 
     index: DataSource
     data_sources: Dict[str, DataSource] = field(default_factory=dict)
-    metadata: Metadata
+    metadata: Metadata = field(
+        default_factory=Metadata
+    )  # TODO: make mandatory during construction
 
     @classmethod
     def from_path(cls, manifest_path):

--- a/express/taxonomy.py
+++ b/express/taxonomy.py
@@ -1,0 +1,37 @@
+"This module defines the taxonomy of the various modalities."
+
+
+class Image:
+    """
+    A single image
+    """
+
+    def __init__(self):
+        pass
+
+    def required_columns(self):
+        return ["width", "height"]
+
+
+class Text:
+    """
+    A single text
+    """
+
+    def __init__(self):
+        pass
+
+    def required_columns(self):
+        return ["len"]
+
+
+class Vector:
+    """
+    A single vector
+    """
+
+    def __init__(self):
+        pass
+
+    def required_columns(self):
+        return ["size"]

--- a/express/taxonomy.py
+++ b/express/taxonomy.py
@@ -24,6 +24,9 @@ class Text:
     def required_columns(self):
         return ["len"]
 
+    def __repr__(self) -> str:
+        return "Text"
+
 
 class Vector:
     """

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -5,19 +5,16 @@ Test scripts for manifest helpers
 
 import pytest
 
-from express.manifest import DataManifest, DataSource, Metadata, DataType
+from express.manifest import DataManifest, DataSource, Metadata
 
 
 @pytest.fixture
 def valid_manifest_data():
     """Generate valid data to populate the metadata"""
-    index = DataSource(location='gs://my-bucket/index.parquet', type=DataType.PARQUET,
-                       extensions=['parquet'])
+    index = DataSource(location='gs://my-bucket/index.parquet', len=100, column_names=['id'])
     data_sources = {
-        'source1': DataSource(location='gs://my-bucket/data1.parquet', type=DataType.PARQUET,
-                              extensions=['parquet']),
-        'source2': DataSource(location='gs://my-bucket/data2.blob', type=DataType.BLOB,
-                              extensions=['blob'])
+        'source1': DataSource(location='gs://my-bucket/data1.parquet', len=100, column_names=['id']),
+        'source2': DataSource(location='gs://my-bucket/data2.blob', len=100, column_names=['id'])
     }
     metadata = Metadata(artifact_bucket='gs://my-bucket/artifacts', run_id='12345',
                         component_id='component1',
@@ -27,8 +24,8 @@ def valid_manifest_data():
 
 
 @pytest.mark.parametrize('invalid_index', [
-    DataSource(location='gs://my-bucket/index.csv', type=DataType.BLOB, extensions=['csv']),
-    DataSource(location='gs://my-bucket/index.parquet', type=DataType.BLOB, extensions=['parquet']),
+    DataSource(location='gs://my-bucket/index.csv', extensions=['csv']),
+    DataSource(location='gs://my-bucket/index.parquet', extensions=['parquet']),
 ])
 def test_invalid_index(invalid_index, valid_manifest_data):
     """Test the validity of an index"""


### PR DESCRIPTION
From the dataset doc:

> Fondant should define a taxonomy of general data types that components can use. We should try to cover as many general cases as we can without making it too complex.

This is a first draft of how this could look like. Basically, each component would need to define expected input and output data sources (they are still called data sources in the code base). Fondant will then check whether those are met based on the input and output manifests.