### PR TITLE
Update manifest class to match discussed specification

### DIFF
--- a/express/exceptions.py
+++ b/express/exceptions.py
@@ -1,0 +1,11 @@
+"""This module defines exceptions thrown by Express."""
+
+from jsonschema.exceptions import ValidationError
+
+
+class ExpressException(Exception):
+    """All custom Express exception should subclass this one."""
+
+
+class InvalidManifest(ValidationError, ExpressException):
+    """Thrown when a manifest cannot be validated against the schema."""

--- a/express/manifest.py
+++ b/express/manifest.py
@@ -1,112 +1,113 @@
-"""
-Script for generating the dataset manifest that will be passed and updated through different
-components of the pipeline
-"""
+"""This module defines classes to represent an Express manifest."""
+
 import json
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import List, Dict
+import pkgutil
+import typing as t
+from dataclasses import dataclass
 
-from dataclasses_json import dataclass_json
+import jsonschema.exceptions
+from jsonschema import Draft4Validator
+
+from express.exceptions import InvalidManifest
 
 
-class DataType(str, Enum):
+@dataclass
+class Field:
+    """Class representing a single field or column in an Express subset."""
+
+    name: str
+    type: str
+
+
+class Subset:
     """
-    Supported types for stored data.
+    Class representing an Express subset.
+
+    Args:
+        specification: The part of the manifest json representing the subset
+        base_path: The base path which the subset location is defined relative to
     """
 
-    PARQUET = "parquet"
-    BLOB = "blob"
+    def __init__(self, specification: dict, *, base_path: str) -> None:
+        self._specification = specification
+        self._base_path = base_path
+
+    @property
+    def location(self) -> str:
+        """The resolved location of the subset"""
+        return self._base_path.rstrip("/") + self._specification["location"]
+
+    @property
+    def fields(self) -> t.Dict[str, Field]:
+        return {
+            name: Field(name=name, type=field["type"])
+            for name, field in self._specification["fields"].items()
+        }
+
+
+class Index(Subset):
+    """Special case of a subset for the index, which has fixed fields"""
+
+    @property
+    def fields(self) -> t.Dict[str, Field]:
+        return {
+            "id": Field(name="id", type="str"),
+            "source": Field(name="source", type="str"),
+        }
+
+
+class Manifest:
+    """
+    Class representing an Express manifest
+
+    Args:
+        specification: The manifest specification as a Python dict
+    """
+
+    def __init__(self, specification: dict) -> None:
+        self._validate_spec(specification)
+        self._specification = specification
 
     @classmethod
-    def is_valid(cls, data_type: str) -> bool:
-        """Check if data type is valid"""
-        return data_type in cls.__members__.values()
+    def _validate_spec(cls, spec: dict) -> None:
+        """Validate a manifest specification against the manifest schema
 
-
-@dataclass
-class DataSource:
-    """
-    Information about the location and contents of a single data source.
-    Args:
-        location (str): the URI of the data root
-        type (Union[DataType, str]): the type of data, which determines how it's interpreted
-        extensions (List[str]): under what file extensions the data is stored.
-        n_files (int): how many files make up the data
-        n_items (int): how many items (e.g. distinct images, captions, etc.) are covered by the
-         data.
-    """
-
-    location: str
-    type: DataType
-    extensions: List[str]
-    n_files: int = field(default_factory=int)
-    n_items: int = field(default_factory=int)
-
-
-@dataclass_json
-@dataclass
-class Metadata:
-    """
-    The metadata associated with the manifest
-    Args:
-        artifact_bucket (str): remote location of all newly created job artifacts.
-        run_id (str): the kfp run id associated with the manifest (kfp.dsl.EXECUTION_ID_PLACEHOLDER)
-        component_id (str): if this metadata is passed as an input to a component, this is the id of
-         the current component. If this metadata is stored as part of a manifest, this is the id of
-        the component that generated the manifest.
-        component_name (str): name of the current or originating component (see component_id for
-         more details).
-        branch (str): the git branch associated with that manifest
-        commit_hash (str): the commit hash associated with that manifest
-        creation_date (str): the creation date of the manifest
-        num_items (int): total number of rows in the index
-    """
-
-    # TODO: get rid of defaults
-    artifact_bucket: str = field(default_factory=str)
-    run_id: str = field(default_factory=str)
-    component_id: str = field(default_factory=str)
-    component_name: str = field(default_factory=str)
-    branch: str = field(default_factory=str)
-    commit_hash: str = field(default_factory=str)
-    creation_date: str = field(default_factory=str)
-    num_items: int = field(default_factory=int)
-
-
-@dataclass_json
-@dataclass
-class DataManifest:
-    """
-    The dataset Manifest
-    Args:
-        index (DataSource): the index parquet file which indexes all the data_sources
-        data_sources (List[DataSource]): Location and metadata of various data sources associated
-         with the index.
-        metadata (Metadata): The metadata associated with the manifest
-
-    """
-
-    index: DataSource
-    data_sources: Dict[str, DataSource] = field(default_factory=dict)
-    metadata: Metadata = field(
-        default_factory=Metadata
-    )  # TODO: make mandatory during construction
-
-    def __post_init__(self):
-        if (self.index.type != DataType.PARQUET) or (
-            not DataType.is_valid(self.index.type)
-        ):
-            raise TypeError("Index needs to be of type 'parquet'.")
-        for name, dataset in self.data_sources.items():
-            if not DataType.is_valid(dataset.type):
-                raise TypeError(
-                    f"Data type '{dataset.type}' for data source '{name}' is not valid."
-                )
+        Raises: InvalidManifest when the manifest is not valid.
+        """
+        spec_schema = json.loads(pkgutil.get_data("express", "schemas/manifest.json"))
+        validator = Draft4Validator(spec_schema)
+        try:
+            validator.validate(spec)
+        except jsonschema.exceptions.ValidationError as e:
+            raise InvalidManifest.create_from(e)
 
     @classmethod
-    def from_path(cls, manifest_path):
-        """Load data manifest from a given manifest path"""
-        with open(manifest_path, encoding="utf-8") as file_:
-            manifest_load = json.load(file_)
-            return DataManifest.from_dict(manifest_load)
+    def from_file(cls, path: str) -> "Manifest":
+        """Load the manifest from the file specified by the provided path"""
+        with open(path, encoding="utf-8") as file_:
+            specification = json.load(file_)
+            return cls(specification)
+
+    def to_file(self, path) -> None:
+        """Dump the manifest to the file specified by the provided path"""
+        with open(path, "w", encoding="utf-8") as file_:
+            json.dump(self._specification, file_)
+
+    @property
+    def metadata(self) -> dict:
+        return self._specification.get("metadata")
+
+    @property
+    def base_path(self) -> str:
+        return self.metadata.get("base_path")
+
+    @property
+    def index(self) -> Index:
+        return Index(self._specification.get("index"), base_path=self.base_path)
+
+    @property
+    def subsets(self) -> t.Dict[str, Subset]:
+        return {
+            name: Subset(subset, base_path=self.base_path)
+            for name, subset in self._specification["subsets"].items()
+        }

--- a/express/schemas/manifest.json
+++ b/express/schemas/manifest.json
@@ -40,7 +40,10 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["str", "int", "float", "bool", "bytes"]
+          "enum": ["bool", "int8", "int16", "int32", "uint8", "uint16", "uint32", "uint64",
+                   "float16", "float32", "float64", "decimal",
+                   "time32", "time64", "timestamp", "date32", "date64", "duration",
+                   "utf8", "binary", "categorical", "list", "struct"]
         }
       },
       "required": ["type"]

--- a/express/schemas/manifest.json
+++ b/express/schemas/manifest.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "base_path": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "base_path"
+      ]
+    },
+    "index": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "location"
+      ]
+    },
+    "subsets": {
+      "$ref": "#/definitions/subsets"
+    }
+  },
+  "required": [
+    "metadata",
+    "index",
+    "subsets"
+  ],
+  "definitions": {
+    "field": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["str", "int", "float", "bool", "bytes"]
+        }
+      },
+      "required": ["type"]
+    },
+    "fields": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/definitions/field"
+      }
+    },
+    "subset": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "pattern": "/.*"
+        },
+        "fields": {
+          "$ref": "#/definitions/fields"
+        }
+      },
+      "required": ["location", "fields"]
+    },
+    "subsets": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/subset"
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 dataclasses-json = "^0.5.7"
+jsonschema = "^4.17.3"
 
 datasets = { version = "^2.10.1", optional = true }
 kfp = { version = "^1.8.19", optional = true }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,56 +1,87 @@
-"""
-Test scripts for manifest helpers
-"""
-# pylint: disable=redefined-outer-name
-
+import json
 import pytest
+from express.exceptions import InvalidManifest
+from express.manifest import Manifest
 
-from express.manifest import DataManifest, DataSource, Metadata, DataType
-
-
-@pytest.fixture
-def valid_manifest_data():
-    """Generate valid data to populate the metadata"""
-    index = DataSource(location='gs://my-bucket/index.parquet', type=DataType.PARQUET,
-                       extensions=['parquet'])
-    data_sources = {
-        'source1': DataSource(location='gs://my-bucket/data1.parquet', type=DataType.PARQUET,
-                              extensions=['parquet']),
-        'source2': DataSource(location='gs://my-bucket/data2.blob', type=DataType.BLOB,
-                              extensions=['blob'])
+VALID_MANIFEST = {
+    "metadata": {
+        "base_path": "gs://bucket"
+    },
+    "index": {
+        "location": "/index"
+    },
+    "subsets": {
+        "images": {
+            "location": "/images",
+            "fields": {
+                "data": {
+                    "type": "bytes"
+                },
+                "height": {
+                    "type": "int"
+                },
+                "width": {
+                    "type": "int"
+                }
+            }
+        },
+        "captions": {
+            "location": "/captions",
+            "fields": {
+                "data": {
+                    "type": "bytes"
+                }
+            }
+        }
     }
-    metadata = Metadata(artifact_bucket='gs://my-bucket/artifacts', run_id='12345',
-                        component_id='component1',
-                        component_name='my-component', branch='main', commit_hash='abc123',
-                        creation_date='2022-01-01', num_items=100)
-    return {'index': index, 'data_sources': data_sources, 'metadata': metadata}
+}
+
+INVALID_MANIFEST = {
+    "metadata": {
+        "base_path": "gs://bucket"
+    },
+    "index": {
+        "location": "/index"
+    },
+    "subsets": {
+        "images": {
+            "location": "/images",
+            "fields": []  # Should be an object
+        }
+    }
+}
 
 
-@pytest.mark.parametrize('invalid_index', [
-    DataSource(location='gs://my-bucket/index.csv', type=DataType.BLOB, extensions=['csv']),
-    DataSource(location='gs://my-bucket/index.parquet', type=DataType.BLOB, extensions=['parquet']),
-])
-def test_invalid_index(invalid_index, valid_manifest_data):
-    """Test the validity of an index"""
-    valid_manifest_data['index'] = invalid_index
-    with pytest.raises(TypeError):
-        DataManifest(**valid_manifest_data)
+def test_manifest_validation():
+    """Test that the manifest is validated correctly on instantiation"""
+    Manifest(VALID_MANIFEST)
+    with pytest.raises(InvalidManifest):
+        Manifest(INVALID_MANIFEST)
 
 
-@pytest.mark.parametrize('invalid_data_source_type', [
-    DataSource(location='gs://my-bucket/data1.parquet', type='invalid', extensions=['parquet']),
-    DataSource(location='gs://my-bucket/data2.blob', type='invalid', extensions=['blob']),
-])
-def test_invalid_data_source_type(invalid_data_source_type, valid_manifest_data):
-    """Test the validity of a data source type"""
-    valid_manifest_data['data_sources']['source1'] = invalid_data_source_type
-    with pytest.raises(TypeError):
-        DataManifest(**valid_manifest_data)
+def test_from_to_file():
+    """Test reading from and writing to file"""
+    tmp_path = "/tmp/manifest.json"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(VALID_MANIFEST, f)
+
+    manifest = Manifest.from_file(tmp_path)
+    assert manifest.metadata == VALID_MANIFEST["metadata"]
+
+    manifest.to_file(tmp_path)
+    with open(tmp_path, encoding="utf-8") as f:
+        assert json.load(f) == VALID_MANIFEST
 
 
-def test_valid_manifest(valid_manifest_data):
-    """Test the validity of populating the manifest with relevant data"""
-    manifest = DataManifest(**valid_manifest_data)
-    assert manifest.index == valid_manifest_data['index']
-    assert manifest.data_sources == valid_manifest_data['data_sources']
-    assert manifest.metadata == valid_manifest_data['metadata']
+def test_attribute_access():
+    """
+    Test that attributes can be accessed as expected:
+    - Fixed properties should be accessible as an attribute
+    - Dynamic properties should be accessible by lookup
+    """
+    manifest = Manifest(VALID_MANIFEST)
+
+    assert manifest.metadata == VALID_MANIFEST["metadata"]
+    assert manifest.index.location == "gs://bucket/index"
+    assert manifest.subsets["images"].location == "gs://bucket/images"
+    assert manifest.subsets["images"].fields["data"].type == "bytes"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -89,20 +89,26 @@ def test_attribute_access():
 
 def test_manifest_creation():
     """Test the stepwise creation of a manifest via the Manifest class"""
-    manifest = Manifest.create("gs://bucket")
+    base_path = "gs://bucket"
+    run_id = "run_id"
+    component_id = "component_id"
+
+    manifest = Manifest.create(base_path=base_path, run_id=run_id, component_id=component_id)
     manifest.add_subset("images", [("width", Type.int32), ("height", Type.int32)])
     manifest.subsets["images"].add_field("data", Type.binary)
 
     assert manifest._specification == {
         "metadata": {
-            "base_path": "gs://bucket",
+            "base_path": base_path,
+            "run_id": run_id,
+            "component_id": component_id,
         },
         "index": {
-            "location": "/index"
+            "location": f"/index/{run_id}/{component_id}"
         },
         "subsets": {
             "images": {
-                "location": "/images",
+                "location": f"/images/{run_id}/{component_id}",
                 "fields": {
                     "width": {
                         "type": "int32",


### PR DESCRIPTION
This PR updates the manifest class to match the discussion on the dataset doc. Let's focus all further discussion on the manifest in this PR.

- I included a schema defining the manifest
- Data sources has been renamed to subsets
- The manifest now defines which fields / columns are available in a subset and their types
- The location for each subset is resolved with the base path defined in the metadata
- I'm no longer leveraging `dataclasses-json` as I don't just want to build a 1 to 1 mapping of the json in Python
- All unused keys have been removed from the manifest

The `Manifest` class is currently mostly focused on making an existing json manifest easily accessible, which is useful for input manifests. We might want to add functionality to create a new manifest programmatically as well, which is useful for output manifests. It might be best that these are two separate classes though, an immutable one for the input manifests and a mutable one for the output manifests.

I'd like to see a similar PR for the component specification as well.